### PR TITLE
CHG: CopyRecordValues

### DIFF
--- a/backend/Origam.Rule/RuleEngine.cs
+++ b/backend/Origam.Rule/RuleEngine.cs
@@ -3533,7 +3533,9 @@ namespace Origam.Rule
 
 						// copy the values into the source row
 						PauseRuleProcessing();
-						bool localChanged = DatasetTools.CopyRecordValues(resultRow, DataRowVersion.Current, rowChanged);
+						bool localChanged = DatasetTools.CopyRecordValues(
+							resultRow, DataRowVersion.Current, rowChanged, 
+							true);
 						ResumeRuleProcessing();
 
 						if(! changed) changed = localChanged;


### PR DESCRIPTION
- New parameter enforceNullValues allows setting null values into the mandatory fields when row state is added.
- The new setting is used during rules resolution.