### PR TITLE
FIX: Invalid tokens for password reset

### DIFF
--- a/backend/Origam.Security.Common/IManager.cs
+++ b/backend/Origam.Security.Common/IManager.cs
@@ -17,7 +17,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
-#endregion
+#endregion
+
 using System.Threading.Tasks;
 using System.Xml;
 using Origam.Security.Common;
@@ -43,7 +44,7 @@ namespace Origam.Security.Identity
         Task<InternalIdentityResult> CreateAsync(IOrigamUser user, string password);
         Task<string> GenerateEmailConfirmationTokenAsync(string userId);
         Task<TokenResult> GetPasswordResetTokenFromEmailAsync(string email);
-        Task<string> GeneratePasswordResetTokenAsync1(string userId);
+        Task<string> GeneratePasswordResetTokenAsync(string userId);
         Task<XmlDocument> GetPasswordAttributesAsync();
     }
 }

--- a/backend/Origam.Security.Identity/IdentityServiceAgent.cs
+++ b/backend/Origam.Security.Identity/IdentityServiceAgent.cs
@@ -706,7 +706,7 @@ namespace Origam.Security.Identity
                     Resources.ErrorUserIdNotGuid);
             }
             Task<string> task = userManager
-                .GeneratePasswordResetTokenAsync1(
+                .GeneratePasswordResetTokenAsync(
                 Parameters["UserId"].ToString());
             if (task.IsFaulted)
             {

--- a/backend/Origam.Security.NetFx/AspNetManagerAdapter.cs
+++ b/backend/Origam.Security.NetFx/AspNetManagerAdapter.cs
@@ -17,7 +17,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
-#endregion
+#endregion
+
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.AspNet.Identity;
@@ -134,7 +135,7 @@ namespace Origam.Security.Identity
                 .GetPasswordResetTokenFromEmailAsync(email);
         }
 
-        public async Task<string> GeneratePasswordResetTokenAsync1(string userId)
+        public async Task<string> GeneratePasswordResetTokenAsync(string userId)
         {
             return await aspNetUserManager.GeneratePasswordResetTokenAsync(
                 userId);

--- a/backend/Origam.ServerCore/Authorization/CoreManagerAdapter.cs
+++ b/backend/Origam.ServerCore/Authorization/CoreManagerAdapter.cs
@@ -194,7 +194,7 @@ namespace Origam.ServerCore.Authorization
                     TokenValidityHours = 0};
             }
 
-            string token = await GenerateEmailConfirmationTokenAsync(user.BusinessPartnerId);
+            string token = await GeneratePasswordResetTokenAsync(user.BusinessPartnerId);
             
             return new TokenResult
             { Token = token,
@@ -202,9 +202,10 @@ namespace Origam.ServerCore.Authorization
                 TokenValidityHours = 24};
         }
 
-        public async Task<string> GeneratePasswordResetTokenAsync1(string userId)
+        public async Task<string> GeneratePasswordResetTokenAsync(string userId)
         {
-            return await GenerateEmailConfirmationTokenAsync(userId);
+            var user = await FindByIdAsync(userId);
+            return await coreUserManager.GeneratePasswordResetTokenAsync(user);
         }
 
         public Task<XmlDocument> GetPasswordAttributesAsync()


### PR DESCRIPTION
- token's purpose was `Confirmation` instead of `ResetPassword`