### PR TITLE
FIX: Invalid tokens for password reset

### DIFF
--- a/backend/Origam.Security.Common/IManager.cs
+++ b/backend/Origam.Security.Common/IManager.cs
@@ -17,7 +17,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
-#endregion
+#endregion
+
 using System.Threading.Tasks;
 using System.Xml;
 using Origam.Security.Common;
@@ -43,7 +44,7 @@ namespace Origam.Security.Identity
         Task<InternalIdentityResult> CreateAsync(IOrigamUser user, string password);
         Task<string> GenerateEmailConfirmationTokenAsync(string userId);
         Task<TokenResult> GetPasswordResetTokenFromEmailAsync(string email);
-        Task<string> GeneratePasswordResetTokenAsync1(string userId);
+        Task<string> GeneratePasswordResetTokenAsync(string userId);
         Task<XmlDocument> GetPasswordAttributesAsync();
         IOrigamUser CreateUserObject(string userName);
     }

--- a/backend/Origam.Security.Identity/IdentityServiceAgent.cs
+++ b/backend/Origam.Security.Identity/IdentityServiceAgent.cs
@@ -707,7 +707,7 @@ namespace Origam.Security.Identity
                     Resources.ErrorUserIdNotGuid);
             }
             Task<string> task = userManager
-                .GeneratePasswordResetTokenAsync1(
+                .GeneratePasswordResetTokenAsync(
                 Parameters["UserId"].ToString());
             if (task.IsFaulted)
             {

--- a/backend/Origam.Security.NetFx/AspNetManagerAdapter.cs
+++ b/backend/Origam.Security.NetFx/AspNetManagerAdapter.cs
@@ -1,0 +1,149 @@
+#region license
+/*
+Copyright 2005 - 2020 Advantage Solutions, s. r. o.
+
+This file is part of ORIGAM (http://www.origam.org).
+
+ORIGAM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ORIGAM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+#endregion
+
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.AspNet.Identity;
+using Origam.Security.Common;
+
+namespace Origam.Security.Identity
+{
+    public class AspNetManagerAdapter: IManager
+    {
+        private readonly AbstractUserManager aspNetUserManager;
+
+        public AspNetManagerAdapter(AbstractUserManager aspNetUserManager)
+        {
+            this.aspNetUserManager = aspNetUserManager;
+        }
+
+        public async  Task<IOrigamUser> FindByNameAsync(string name)
+        {
+           return await aspNetUserManager.FindByNameAsync(name);
+        }
+
+        //
+        public async Task<bool> ChangePasswordQuestionAndAnswerAsync(string userName, string password,
+            string question, string answer)
+        {
+            return await aspNetUserManager.ChangePasswordQuestionAndAnswerAsync(
+                userName, password,question, answer);
+        }
+
+        public async Task<bool> IsLockedOutAsync(string userId)
+        {
+            return await aspNetUserManager.IsLockedOutAsync(userId);
+        }
+
+        public async Task<bool> GetTwoFactorEnabledAsync(string userId)
+        {
+            return await aspNetUserManager.GetTwoFactorEnabledAsync(userId);
+        }
+
+        public async Task<bool> SetTwoFactorEnabledAsync(string userId, bool enabled)
+        {
+            return (await aspNetUserManager.SetTwoFactorEnabledAsync(userId, enabled))
+                .Succeeded;
+        }
+
+        public async Task<bool> IsEmailConfirmedAsync(string userId)
+        {
+            return await aspNetUserManager.IsEmailConfirmedAsync(userId);
+        }
+
+        public async Task<bool> UnlockUserAsync(string userName)
+        {
+            return await aspNetUserManager.UnlockUserAsync(userName);
+        }
+
+        public async Task<InternalIdentityResult> ConfirmEmailAsync(string userId)
+        {
+            return (await aspNetUserManager.ConfirmEmailAsync(userId))
+                .ToInternalIdentityResult();
+        }
+
+        public async Task<InternalIdentityResult> ConfirmEmailAsync(string userId, string token)
+        {
+            return (await aspNetUserManager.ConfirmEmailAsync(userId, token))
+                .ToInternalIdentityResult();
+        }
+
+        public async Task<InternalIdentityResult> ChangePasswordAsync(string userId, string currentPassword, string newPassword)
+        {
+            return (await aspNetUserManager.ChangePasswordAsync(userId, currentPassword,
+                newPassword))
+                .ToInternalIdentityResult();
+        }
+
+        public async Task<InternalIdentityResult> ResetPasswordFromUsernameAsync(string userName, string token, string newPassword)
+        {
+            return (await aspNetUserManager.ResetPasswordFromUsernameAsync(
+                userName, token, newPassword))
+                .ToInternalIdentityResult();
+        }
+
+        public async Task<InternalIdentityResult> DeleteAsync(IOrigamUser user)
+        {
+            return (await aspNetUserManager.DeleteAsync((OrigamUser) user))
+                .ToInternalIdentityResult();
+        }
+
+        public async Task<InternalIdentityResult> UpdateAsync(IOrigamUser user)
+        {
+            return (await aspNetUserManager.UpdateAsync((OrigamUser)user))
+                .ToInternalIdentityResult();
+        }
+
+        public void SendNewUserToken(string userName)
+        {
+            aspNetUserManager.SendNewUserToken(userName);
+        }
+
+        public async Task<InternalIdentityResult> CreateAsync(IOrigamUser user, string password)
+        {
+            return (await aspNetUserManager.CreateAsync((OrigamUser) user,
+                password)).ToInternalIdentityResult();
+        }
+
+        public async Task<string> GenerateEmailConfirmationTokenAsync(string userId)
+        {
+            return await aspNetUserManager.GenerateEmailConfirmationTokenAsync(
+                userId);
+        }
+
+        public async Task<TokenResult> GetPasswordResetTokenFromEmailAsync(string email)
+        {
+            return await aspNetUserManager
+                .GetPasswordResetTokenFromEmailAsync(email);
+        }
+
+        public async Task<string> GeneratePasswordResetTokenAsync(string userId)
+        {
+            return await aspNetUserManager.GeneratePasswordResetTokenAsync(
+                userId);
+        }
+
+        public async Task<XmlDocument> GetPasswordAttributesAsync()
+        {
+            return await aspNetUserManager.GetPasswordAttributesAsync();
+        }
+    }
+}

--- a/backend/Origam.ServerCore/Authorization/CoreManagerAdapter.cs
+++ b/backend/Origam.ServerCore/Authorization/CoreManagerAdapter.cs
@@ -189,7 +189,7 @@ namespace Origam.ServerCore.Authorization
                     TokenValidityHours = 0};
             }
 
-            string token = await GenerateEmailConfirmationTokenAsync(user.BusinessPartnerId);
+            string token = await GeneratePasswordResetTokenAsync(user.BusinessPartnerId);
             
             return new TokenResult
             { Token = token,
@@ -197,9 +197,10 @@ namespace Origam.ServerCore.Authorization
                 TokenValidityHours = 24};
         }
 
-        public async Task<string> GeneratePasswordResetTokenAsync1(string userId)
+        public async Task<string> GeneratePasswordResetTokenAsync(string userId)
         {
-            return await GenerateEmailConfirmationTokenAsync(userId);
+            var user = await FindByIdAsync(userId);
+            return await coreUserManager.GeneratePasswordResetTokenAsync(user);
         }
 
         public Task<XmlDocument> GetPasswordAttributesAsync()


### PR DESCRIPTION
- token's purpose was `Confirmation` instead of `ResetPassword`