### PR TITLE
FIX: Invalid tokens for password reset

### DIFF
--- a/backend/Origam.Security.Common/IManager.cs
+++ b/backend/Origam.Security.Common/IManager.cs
@@ -17,7 +17,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
-#endregion
+#endregion
+
 using System.Threading.Tasks;
 using System.Xml;
 using Origam.Security.Common;
@@ -43,7 +44,7 @@ namespace Origam.Security.Identity
         Task<InternalIdentityResult> CreateAsync(IOrigamUser user, string password);
         Task<string> GenerateEmailConfirmationTokenAsync(string userId);
         Task<TokenResult> GetPasswordResetTokenFromEmailAsync(string email);
-        Task<string> GeneratePasswordResetTokenAsync1(string userId);
+        Task<string> GeneratePasswordResetTokenAsync(string userId);
         Task<XmlDocument> GetPasswordAttributesAsync();
         IOrigamUser CreateUserObject(string userName);
     }

--- a/backend/Origam.Security.Identity/IdentityServiceAgent.cs
+++ b/backend/Origam.Security.Identity/IdentityServiceAgent.cs
@@ -707,7 +707,7 @@ namespace Origam.Security.Identity
                     Resources.ErrorUserIdNotGuid);
             }
             Task<string> task = userManager
-                .GeneratePasswordResetTokenAsync1(
+                .GeneratePasswordResetTokenAsync(
                 Parameters["UserId"].ToString());
             if (task.IsFaulted)
             {

--- a/backend/Origam.Server/Authorization/CoreManagerAdapter.cs
+++ b/backend/Origam.Server/Authorization/CoreManagerAdapter.cs
@@ -188,7 +188,7 @@ namespace Origam.Server.Authorization
                     TokenValidityHours = 0};
             }
 
-            string token = await GenerateEmailConfirmationTokenAsync(user.BusinessPartnerId);
+            string token = await GeneratePasswordResetTokenAsync(user.BusinessPartnerId);
             
             return new TokenResult
             { Token = token,
@@ -196,9 +196,10 @@ namespace Origam.Server.Authorization
                 TokenValidityHours = 24};
         }
 
-        public async Task<string> GeneratePasswordResetTokenAsync1(string userId)
+        public async Task<string> GeneratePasswordResetTokenAsync(string userId)
         {
-            return await GenerateEmailConfirmationTokenAsync(userId);
+            var user = await FindByIdAsync(userId);
+            return await coreUserManager.GeneratePasswordResetTokenAsync(user);
         }
 
         public Task<XmlDocument> GetPasswordAttributesAsync()


### PR DESCRIPTION
- token's purpose was `Confirmation` instead of `ResetPassword`