### PR TITLE
NEW: Cookie lifetime can be set in the appsettings.json

### DIFF
--- a/backend/Origam.Server/Configuration/IdentityServerConfig.cs
+++ b/backend/Origam.Server/Configuration/IdentityServerConfig.cs
@@ -40,6 +40,9 @@ namespace Origam.Server.Configuration
         public WebClient WebClient { get; }
         public MobileClient MobileClient { get; }
         public ServerClient ServerClient { get; }
+        
+        public bool CookieSlidingExpiration { get; } 
+        public int CookieExpirationMinutes { get; }
 
         public IdentityServerConfig(IConfiguration configuration)
         {
@@ -49,7 +52,9 @@ namespace Origam.Server.Configuration
             UseGoogleLogin = identityServerSection.GetValue("UseGoogleLogin", false);
             GoogleClientId = identityServerSection["GoogleClientId"] ?? "";
             GoogleClientSecret = identityServerSection["GoogleClientSecret"] ?? "";
-            
+            CookieSlidingExpiration = identityServerSection.GetValue("CookieSlidingExpiration", true);
+            CookieExpirationMinutes = identityServerSection.GetValue("CookieExpirationMinutes", 60);
+
             var webClientSection = identityServerSection
                 .GetSection("WebClient");
             if (webClientSection.GetChildren().Count() != 0)

--- a/backend/Origam.Server/Startup.cs
+++ b/backend/Origam.Server/Startup.cs
@@ -139,7 +139,13 @@ namespace Origam.Server
                     identityServerConfig.PathToJwtCertificate,
                     identityServerConfig.PasswordForJwtCertificate))
                 .AddInMemoryApiScopes(Settings.GetApiScopes());
-            
+           
+           services.ConfigureApplicationCookie(options =>
+           {
+               options.ExpireTimeSpan = TimeSpan.FromMinutes(identityServerConfig.CookieExpirationMinutes);
+               options.SlidingExpiration = identityServerConfig.CookieSlidingExpiration;
+           });
+           
            services.AddSoapCore();
            services.AddSingleton<DataServiceSoap>();
            services.AddSingleton<WorkflowServiceSoap>();

--- a/backend/Origam.Server/TemplateFiles/_appsettings.json
+++ b/backend/Origam.Server/TemplateFiles/_appsettings.json
@@ -27,8 +27,8 @@
     "Html5ClientLogoUrl": "/customAssets/someFile2.png"
   },
   "IdentityServerConfig": {
-    "CookieExpirationMinutes": 1440,
-    "CookieSlidingExpiration": false,
+    "CookieExpirationMinutes": 60,
+    "CookieSlidingExpiration": true,
     "PathToJwtCertificate": "serverCore.pfx",
     "PasswordForJwtCertificate": "bla",
     "UseGoogleLogin": "false",

--- a/backend/Origam.Server/TemplateFiles/_appsettings.json
+++ b/backend/Origam.Server/TemplateFiles/_appsettings.json
@@ -27,6 +27,8 @@
     "Html5ClientLogoUrl": "/customAssets/someFile2.png"
   },
   "IdentityServerConfig": {
+    "CookieExpirationMinutes": 1440,
+    "CookieSlidingExpiration": false,
     "PathToJwtCertificate": "serverCore.pfx",
     "PasswordForJwtCertificate": "bla",
     "UseGoogleLogin": "false",


### PR DESCRIPTION
defaults: "CookieExpirationMinutes": 60, "CookieSlidingExpiration": true