### PR TITLE
FIX: Master record was not changed after clicking on a different row …

### DIFF
--- a/frontend-html/src/model/entities/DataViewLifecycle/DataViewLifecycle.ts
+++ b/frontend-html/src/model/entities/DataViewLifecycle/DataViewLifecycle.ts
@@ -113,6 +113,8 @@ export class DataViewLifecycle implements IDataViewLifecycle {
     } finally {
       if (wasRunning) {
         await this.startSelectedRowReaction(true);
+      }else{
+        await this.onSelectedRowIdChangeImm();
       }
     }
   }
@@ -144,6 +146,7 @@ export class DataViewLifecycle implements IDataViewLifecycle {
       const api = getApi(this);
       this.changeMasterRowCanceller && this.changeMasterRowCanceller();
       this.changeMasterRowCanceller = api.createCanceller();
+      console.log("getSelectedRowId(this)!: "+ getSelectedRowId(this)!)
       const crudResult = yield api.setMasterRecord(
         {
           SessionFormIdentifier: getSessionId(this),

--- a/frontend-html/src/model/entities/DataViewLifecycle/DataViewLifecycle.ts
+++ b/frontend-html/src/model/entities/DataViewLifecycle/DataViewLifecycle.ts
@@ -113,7 +113,7 @@ export class DataViewLifecycle implements IDataViewLifecycle {
     } finally {
       if (wasRunning) {
         await this.startSelectedRowReaction(true);
-      }else{
+      } else {
         await this.onSelectedRowIdChangeImm();
       }
     }

--- a/frontend-html/src/model/entities/TablePanelView/TablePanelView.tsx
+++ b/frontend-html/src/model/entities/TablePanelView/TablePanelView.tsx
@@ -194,7 +194,7 @@ export class TablePanelView implements ITablePanelView {
           if (isEditing) {
             this.setEditing(false);
           }
-          this.selectCell(this.dataTable.getRowId(row) as string, property.id);
+          yield*this.selectCellAsync(this.dataTable.getRowId(row) as string, property.id);
           if (isEditing) {
             this.setEditing(true);
           }
@@ -202,7 +202,7 @@ export class TablePanelView implements ITablePanelView {
       }
     } else {
       const rowId = this.dataTable.getRowId(row);
-      yield*this.selectCellAsync(columnId, rowId);
+      yield*this.selectCellAsync(rowId, columnId);
 
       if (!isReadOnly(property!, rowId)) {
         yield*onFieldChangeG(this)({
@@ -218,7 +218,7 @@ export class TablePanelView implements ITablePanelView {
     }
   }
 
-  private*selectCellAsync(columnId: string, rowId: string) {
+  private*selectCellAsync(rowId: string, columnId: string,) {
     this.selectedColumnId = columnId;
     const dataView = getDataView(this);
     if (dataView.selectedRowId === rowId) {


### PR DESCRIPTION
…and saving changes

because the page was reloaded while changing the row and the RecordChangedReaction was paused as a consequence of that. The reload was caused by result of a call to SaveData IResponseOperation.FormSaved