### PR TITLE
FIX: Calendar widget was overlaid with the date text

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.module.scss
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.module.scss
@@ -39,6 +39,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 .input {
   @include input;
+  padding-right: 18px;
 }
 
 .notification {


### PR DESCRIPTION
if the date input was too short