### PR TITLE
FIX: Calendar widget was overlaid with the date text

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor.module.scss
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor.module.scss
@@ -152,6 +152,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 .input {
   @include input;
+  padding-right: 18px;
 }
 
 .notification {


### PR DESCRIPTION
if the date input was too short