### PR TITLE
Removal of "dbo" prefix from database objects (so db users with different default schema than dbo can be used).

### DIFF
--- a/backend/Origam.DA.Service/MsSqlDataService.cs
+++ b/backend/Origam.DA.Service/MsSqlDataService.cs
@@ -554,7 +554,7 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0)",
 
         public override string CreateBusinessPartnerInsert(QueryParameterCollection parameters)
         {
-            return string.Format("INSERT INTO [dbo].[BusinessPartner] ([FirstName],[UserName],[Name],[Id],[UserEmail]) " +
+            return string.Format("INSERT INTO [BusinessPartner] ([FirstName],[UserName],[Name],[Id],[UserEmail]) " +
                 "VALUES ('{0}','{1}','{2}','{3}','{4}')",
                 parameters.Cast<QueryParameter>().Where(param => param.Name== "FirstName").Select(param =>param.Value).FirstOrDefault(),
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "UserName").Select(param => param.Value).FirstOrDefault(),
@@ -565,7 +565,7 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0)",
 
         public override string CreateOrigamUserInsert(QueryParameterCollection parameters)
         {
-            return string.Format("INSERT INTO [dbo].[OrigamUser] " +
+            return string.Format("INSERT INTO [OrigamUser] " +
                 "([UserName],[IsLockedOut],[EmailConfirmed],[refBusinessPartnerId],[Password],[Id],[FailedPasswordAttemptCount],[Is2FAEnforced]) " +
                 "VALUES ('{0}',{1},{2},'{3}','{4}','{5}','{6}','{7}')", 
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "UserName").Select(param => param.Value).FirstOrDefault(),
@@ -577,7 +577,7 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0)",
 
         public override string CreateBusinessPartnerRoleIdInsert(QueryParameterCollection parameters)
         {
-            return string.Format("INSERT INTO [dbo].[BusinessPartnerOrigamRole] ([Id],[refBusinessPartnerId],[refOrigamRoleId]) " +
+            return string.Format("INSERT INTO [BusinessPartnerOrigamRole] ([Id],[refBusinessPartnerId],[refOrigamRoleId]) " +
                 "VALUES ('{0}','{1}','{2}')",
                 Guid.NewGuid().ToString(),
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "Id").Select(param => param.Value).FirstOrDefault(),
@@ -586,7 +586,7 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0)",
 
         public override string AlreadyCreatedUser(QueryParameterCollection parameters)
         {
-            return string.Format("UPDATE [dbo].[OrigamParameters] SET [BooleanValue] = 1 WHERE [Id] = 'e42f864f-5018-4967-abdc-5910439adc9a'");
+            return string.Format("UPDATE [OrigamParameters] SET [BooleanValue] = 1 WHERE [Id] = 'e42f864f-5018-4967-abdc-5910439adc9a'");
         }
 
         protected override void ResetTransactionIsolationLevel(IDbCommand command)

--- a/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net20-full/log4net.xml
+++ b/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net20-full/log4net.xml
@@ -42,7 +42,7 @@
             <example>
             An example of a SQL Server table that could be logged to:
             <code lang="SQL">
-            CREATE TABLE [dbo].[Log] ( 
+            CREATE TABLE [Log] ( 
               [ID] [int] IDENTITY (1, 1) NOT NULL ,
               [Date] [datetime] NOT NULL ,
               [Thread] [varchar] (255) NOT NULL ,

--- a/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net35-client/log4net.xml
+++ b/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net35-client/log4net.xml
@@ -42,7 +42,7 @@
             <example>
             An example of a SQL Server table that could be logged to:
             <code lang="SQL">
-            CREATE TABLE [dbo].[Log] ( 
+            CREATE TABLE [Log] ( 
               [ID] [int] IDENTITY (1, 1) NOT NULL ,
               [Date] [datetime] NOT NULL ,
               [Thread] [varchar] (255) NOT NULL ,

--- a/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net35-full/log4net.xml
+++ b/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net35-full/log4net.xml
@@ -42,7 +42,7 @@
             <example>
             An example of a SQL Server table that could be logged to:
             <code lang="SQL">
-            CREATE TABLE [dbo].[Log] ( 
+            CREATE TABLE [Log] ( 
               [ID] [int] IDENTITY (1, 1) NOT NULL ,
               [Date] [datetime] NOT NULL ,
               [Thread] [varchar] (255) NOT NULL ,

--- a/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net40-client/log4net.xml
+++ b/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net40-client/log4net.xml
@@ -42,7 +42,7 @@
             <example>
             An example of a SQL Server table that could be logged to:
             <code lang="SQL">
-            CREATE TABLE [dbo].[Log] ( 
+            CREATE TABLE [Log] ( 
               [ID] [int] IDENTITY (1, 1) NOT NULL ,
               [Date] [datetime] NOT NULL ,
               [Thread] [varchar] (255) NOT NULL ,

--- a/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net40-full/log4net.xml
+++ b/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net40-full/log4net.xml
@@ -42,7 +42,7 @@
             <example>
             An example of a SQL Server table that could be logged to:
             <code lang="SQL">
-            CREATE TABLE [dbo].[Log] ( 
+            CREATE TABLE [Log] ( 
               [ID] [int] IDENTITY (1, 1) NOT NULL ,
               [Date] [datetime] NOT NULL ,
               [Thread] [varchar] (255) NOT NULL ,

--- a/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net45-full/log4net.xml
+++ b/backend/OrigamArchitect/packages/log4net.2.0.8/lib/net45-full/log4net.xml
@@ -42,7 +42,7 @@
             <example>
             An example of a SQL Server table that could be logged to:
             <code lang="SQL">
-            CREATE TABLE [dbo].[Log] ( 
+            CREATE TABLE [Log] ( 
               [ID] [int] IDENTITY (1, 1) NOT NULL ,
               [Date] [datetime] NOT NULL ,
               [Thread] [varchar] (255) NOT NULL ,

--- a/frontend-html/tests_e2e/DataBaseData/clearScreenConfiguration.sql
+++ b/frontend-html/tests_e2e/DataBaseData/clearScreenConfiguration.sql
@@ -1,3 +1,3 @@
 CREATE PROCEDURE clearScreenConfiguration
 AS
-DELETE FROM [dbo].[OrigamFormPanelConfig];
+DELETE FROM [OrigamFormPanelConfig];

--- a/model-root/model/Chat/DeploymentVersion/Chat/1.0.1.origam___commandText___9cafcfab-ea8f-4da3-a770-37bf90ce2990.txt
+++ b/model-root/model/Chat/DeploymentVersion/Chat/1.0.1.origam___commandText___9cafcfab-ea8f-4da3-a770-37bf90ce2990.txt
@@ -38,7 +38,7 @@ FETCH NEXT FROM load_cursor INTO @Index_Name, @Index_Table, @Column_Name,@Obj_id
  WHILE @@FETCH_STATUS = 0 
 BEGIN 
 	print 'Working on ' + @Index_Table +' '+ @Index_Name +' '+ CONVERT(varchar(255),@Obj_id);
-	SET @dropIndex = 'ALTER TABLE [dbo].['+@Index_Table+'] DROP CONSTRAINT ['+@Index_Name+'] WITH ( ONLINE = OFF );'
+	SET @dropIndex = 'ALTER TABLE ['+@Index_Table+'] DROP CONSTRAINT ['+@Index_Name+'] WITH ( ONLINE = OFF );'
 	EXECUTE sp_executesql @dropIndex;
 	SET @nonclusteredname = 'ALTER TABLE '+@Index_Table+' ADD CONSTRAINT ['+@Index_Table + '_NonClusteredIndex_'  +  CONVERT(varchar(255),NEWID())+'] PRIMARY KEY NONCLUSTERED (Id);'
 	EXECUTE sp_executesql @nonclusteredname;

--- a/model-root/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___95c0c60e-574c-42be-98c1-8ab1ccac9f15.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___95c0c60e-574c-42be-98c1-8ab1ccac9f15.txt
@@ -1,4 +1,4 @@
-﻿INSERT [dbo].[AsapParameters] ([FloatValue], [StringValue], [DateValue], [BooleanValue], [IntValue],
+﻿INSERT [AsapParameters] ([FloatValue], [StringValue], [DateValue], [BooleanValue], [IntValue],
  [GuidValue], [CurrencyValue], [RecordUpdated], [RecordCreatedServer], [Id], [RecordUpdatedServer],
   [RecordCreatedBy], [RecordCreated], [RecordUpdatedBy]) 
 VALUES (NULL, NULL, NULL, 0, 0, N'00000000-0000-0000-0000-000000000000', 0.0000, NULL, NULL, 

--- a/model-root/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___bacd2e7b-d380-4bf1-bfe6-05366f277361.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___bacd2e7b-d380-4bf1-bfe6-05366f277361.txt
@@ -1,12 +1,11 @@
-﻿
-CREATE  VIEW [dbo].[BusinessPartnerLookup]
+﻿CREATE VIEW [BusinessPartnerLookup]
 AS
 SELECT
 	cast(BusinessPartner.Name + ISNULL(' ' + BusinessPartner.FirstName, '') + ISNULL(N', ' + ParentBusinessPartner.Name, N'') as nvarchar(1000)) AS LookupText,
 	BusinessPartner.*
 FROM
-	dbo.BusinessPartner BusinessPartner 
-	left outer join dbo.BusinessPartner ParentBusinessPartner
+	BusinessPartner BusinessPartner 
+	left outer join BusinessPartner ParentBusinessPartner
 		ON ParentBusinessPartner.Id = BusinessPartner.ParentId
 
 

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___617ae0bc-c9ea-4dc5-8981-4785fd20424e.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___617ae0bc-c9ea-4dc5-8981-4785fd20424e.txt
@@ -1,1 +1,1 @@
-﻿GRANT EXEC ON TYPE::[dbo].[AsapListValue] TO [public]
+﻿GRANT EXEC ON TYPE::[AsapListValue] TO [public]

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___cf5652d6-47c7-44c8-9569-54e7719c2806.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___cf5652d6-47c7-44c8-9569-54e7719c2806.txt
@@ -1,4 +1,4 @@
-﻿create type dbo.AsapListValue as TABLE
+﻿create type AsapListValue as TABLE
 (
 	ListValue nvarchar(max) not null
 )

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___01f92cea-3c5a-4abf-ae3a-154cd8d5655c.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___01f92cea-3c5a-4abf-ae3a-154cd8d5655c.txt
@@ -1,2 +1,1 @@
-﻿
-DROP VIEW [dbo].[BusinessPartnerLookup]
+﻿DROP VIEW [BusinessPartnerLookup]

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___86c0f1c7-80c8-4cb2-a092-a638577f2aaf.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___86c0f1c7-80c8-4cb2-a092-a638577f2aaf.txt
@@ -1,12 +1,11 @@
-﻿
-CREATE  VIEW [dbo].[BusinessPartnerLookup]
+﻿CREATE VIEW [BusinessPartnerLookup]
 AS
 SELECT
 	cast(BusinessPartner.Name + ISNULL(' ' + BusinessPartner.FirstName, '') + ISNULL(N', ' + ParentBusinessPartner.Name, N'') as nvarchar(1000)) AS LookupText,
 	BusinessPartner.*
 FROM
-	dbo.BusinessPartner BusinessPartner 
-	left outer join dbo.BusinessPartner ParentBusinessPartner
+	BusinessPartner BusinessPartner 
+	left outer join BusinessPartner ParentBusinessPartner
 		ON ParentBusinessPartner.Id = BusinessPartner.ParentId
 
 

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.14.origam___commandText___827c6068-12e8-47fc-8b25-f255d3f0170c.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.14.origam___commandText___827c6068-12e8-47fc-8b25-f255d3f0170c.txt
@@ -24,25 +24,25 @@ VALUES ('81fef0eb-8492-4a26-9532-44b8567d0a1b', 'Deutsch (Schweiz)', 'de-CH', SY
 
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'StateEntry')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'StateEntry', NULL, NULL, N'371e5c12-3896-4bab-bfd1-a25f74d25104', CAST(0x0000A46800F2D16B AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'StateEntry', NULL, NULL, N'371e5c12-3896-4bab-bfd1-a25f74d25104', CAST(0x0000A46800F2D16B AS DateTime), NULL)
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'StateTransition')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'StateTransition', NULL, NULL, N'02b5f4d9-2187-44f6-8c32-4cd76c099fd6', CAST(0x0000A46800F2D16C AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'StateTransition', NULL, NULL, N'02b5f4d9-2187-44f6-8c32-4cd76c099fd6', CAST(0x0000A46800F2D16C AS DateTime), NULL)
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'StateExit')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'StateExit', NULL, NULL, N'd4b3b294-6a20-45d8-80bd-1583901e5ac3', CAST(0x0000A46800F2D16C AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'StateExit', NULL, NULL, N'd4b3b294-6a20-45d8-80bd-1583901e5ac3', CAST(0x0000A46800F2D16C AS DateTime), NULL)
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'RecordCreated')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'RecordCreated', NULL, NULL, N'8b2464f5-3278-433c-b68e-74c339c19ddb', CAST(0x0000A46800F2D16D AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'RecordCreated', NULL, NULL, N'8b2464f5-3278-433c-b68e-74c339c19ddb', CAST(0x0000A46800F2D16D AS DateTime), NULL)
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'RecordUpdated')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'RecordUpdated', NULL, NULL, N'6828f423-f9f5-4011-b0bf-305473731fd7', CAST(0x0000A46800F2D16D AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'RecordUpdated', NULL, NULL, N'6828f423-f9f5-4011-b0bf-305473731fd7', CAST(0x0000A46800F2D16D AS DateTime), NULL)
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'RecordDeleted')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'RecordDeleted', NULL, NULL, N'aa050ca9-b3a6-4abd-aced-146895b379ea', CAST(0x0000A46800F2D16D AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'RecordDeleted', NULL, NULL, N'aa050ca9-b3a6-4abd-aced-146895b379ea', CAST(0x0000A46800F2D16D AS DateTime), NULL)
 
 IF NOT EXISTS (select * from AsapStateMachineEventType WHERE Name = 'ValueUpdated')
-INSERT [dbo].[AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'ValueUpdated', NULL, NULL, N'c14b5bc9-bcd2-4e0a-a254-77a09606bf87', CAST(0x0000A46800F2D16D AS DateTime), NULL)
+INSERT [AsapStateMachineEventType] ([Name], [RecordCreatedBy], [RecordUpdatedBy], [Id], [RecordCreated], [RecordUpdated]) VALUES (N'ValueUpdated', NULL, NULL, N'c14b5bc9-bcd2-4e0a-a254-77a09606bf87', CAST(0x0000A46800F2D16D AS DateTime), NULL)
 
 
 

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.28.origam___commandText___75f3c5c0-931d-495f-880a-d489647cf527.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.28.origam___commandText___75f3c5c0-931d-495f-880a-d489647cf527.txt
@@ -1,2 +1,2 @@
-﻿INSERT INTO [dbo].[WorkQueueExternalSourceType] ([Id], [Name])
+﻿INSERT INTO [WorkQueueExternalSourceType] ([Id], [Name])
 VALUES ('58c4ef05-537b-489e-bdf1-bbc3ed109e55', 'WebSphere MQ')

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.29.origam___commandText___f89cb9ff-c04f-4861-b861-117da71fbc36.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.29.origam___commandText___f89cb9ff-c04f-4861-b861-117da71fbc36.txt
@@ -1,2 +1,2 @@
-﻿INSERT INTO [dbo].[WorkQueueExternalSourceType] ([Id], [Name])
+﻿INSERT INTO [WorkQueueExternalSourceType] ([Id], [Name])
 VALUES ('76402268-6e7e-4ee4-bbf5-ae054b2eb793', 'IATA BSP File')

--- a/model-root/model/Root/DeploymentVersion/_origam_root/4.30.origam___commandText___369f17e7-896c-4519-baa4-9e83491ee45e.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/4.30.origam___commandText___369f17e7-896c-4519-baa4-9e83491ee45e.txt
@@ -1,2 +1,2 @@
-﻿INSERT INTO [dbo].[WorkQueueExternalSourceType] ([Id], [Name])
+﻿INSERT INTO [WorkQueueExternalSourceType] ([Id], [Name])
 VALUES ('5c43e42b-d9e4-4a2e-9d3c-d12193acc390', 'Indexed File')

--- a/model-root/model/Root/DeploymentVersion/_origam_root/5.1.5.origam___commandText___95fad64b-1945-4aae-9fb5-2586084ef42c.txt
+++ b/model-root/model/Root/DeploymentVersion/_origam_root/5.1.5.origam___commandText___95fad64b-1945-4aae-9fb5-2586084ef42c.txt
@@ -29,7 +29,7 @@ FETCH NEXT FROM load_cursor INTO @Index_Name, @Index_Table, @Column_Name,@Obj_id
  WHILE @@FETCH_STATUS = 0 
 BEGIN 
 	print 'Working on ' + @Index_Table +' '+ @Index_Name +' '+ CONVERT(varchar(255),@Obj_id);
-	SET @dropIndex = 'ALTER TABLE [dbo].['+@Index_Table+'] DROP CONSTRAINT ['+@Index_Name+'] WITH ( ONLINE = OFF );'
+	SET @dropIndex = 'ALTER TABLE ['+@Index_Table+'] DROP CONSTRAINT ['+@Index_Name+'] WITH ( ONLINE = OFF );'
 	EXECUTE sp_executesql @dropIndex;
 	SET @nonclusteredname = 'ALTER TABLE '+@Index_Table+' ADD CONSTRAINT ['+@Index_Table + '_NonClusteredIndex_'  +  CONVERT(varchar(255),NEWID())+'] PRIMARY KEY NONCLUSTERED (Id);'
 	EXECUTE sp_executesql @nonclusteredname;

--- a/model-root/model/Security/DeploymentVersion/Security/1.1.origam___commandText___7e35fff3-4448-4d73-880f-74f7250b22fc.txt
+++ b/model-root/model/Security/DeploymentVersion/Security/1.1.origam___commandText___7e35fff3-4448-4d73-880f-74f7250b22fc.txt
@@ -30,7 +30,7 @@ ALTER TABLE BusinessPartnerAsapRole WITH NOCHECK ADD CONSTRAINT
 	FK_BusinessPartnerAsapRole_refAsapRoleId_AsapRole FOREIGN KEY
 	(
 	refAsapRoleId
-	) REFERENCES dbo.AsapRole
+	) REFERENCES AsapRole
 	(
 	Id
 	)

--- a/model-root/model/Security/DeploymentVersion/Security/5.2.1.origam___commandText___de84cd6b-40d2-49a4-85db-79f331f50f2d.txt
+++ b/model-root/model/Security/DeploymentVersion/Security/5.2.1.origam___commandText___de84cd6b-40d2-49a4-85db-79f331f50f2d.txt
@@ -1,7 +1,6 @@
 ﻿IF (NOT EXISTS (SELECT * 
                  FROM INFORMATION_SCHEMA.TABLES 
-                 WHERE TABLE_SCHEMA = 'dbo' 
-                 AND  TABLE_NAME = 'OrigamIdentityGrant'))
+                 WHERE TABLE_NAME = 'OrigamIdentityGrant'))
 BEGIN   
 	CREATE TABLE [OrigamIdentityGrant] (
 		[Key] NVarChar(100) NULL,

--- a/model-root/model/Security/DeploymentVersion/Security/5.3.origam___commandText___af575cf0-0c21-4c01-88c5-75b5846e8d05.txt
+++ b/model-root/model/Security/DeploymentVersion/Security/5.3.origam___commandText___af575cf0-0c21-4c01-88c5-75b5846e8d05.txt
@@ -1,4 +1,4 @@
-﻿CREATE TRIGGER LockOutSynchronizer ON [dbo].[OrigamUser]
+﻿CREATE TRIGGER LockOutSynchronizer ON [OrigamUser]
 	FOR UPDATE
 AS
 
@@ -27,10 +27,10 @@ BEGIN
 			SET @lastLocoutDateValue = NULL
 		END
 
-	    UPDATE [dbo].[OrigamUser]
+	    UPDATE [OrigamUser]
 			SET LastLockoutDate = @lastLocoutDateValue
-		FROM [dbo].[OrigamUser]
-		INNER JOIN INSERTED i on i.Id = [dbo].[OrigamUser].Id
+		FROM [OrigamUser]
+		INNER JOIN INSERTED i on i.Id = [OrigamUser].Id
 	END
 
 	ELSE 
@@ -53,10 +53,10 @@ BEGIN
 				SET @IsLockedOutValue = 1
 			END
 
-			UPDATE [dbo].[OrigamUser]
+			UPDATE [OrigamUser]
 				SET IsLockedOut =  @IsLockedOutValue
-			FROM [dbo].[OrigamUser]
-			INNER JOIN INSERTED i on i.Id = [dbo].[OrigamUser].Id
+			FROM [OrigamUser]
+			INNER JOIN INSERTED i on i.Id = [OrigamUser].Id
 		END
 	END
 END

--- a/model-tests/model/AutomaticTests/DeploymentVersion/AutomaticTests/1.0.0.origam___commandText___34639502-577a-4251-9c3c-6a59d3bbeec9.txt
+++ b/model-tests/model/AutomaticTests/DeploymentVersion/AutomaticTests/1.0.0.origam___commandText___34639502-577a-4251-9c3c-6a59d3bbeec9.txt
@@ -1,4 +1,4 @@
-﻿INSERT INTO [dbo].[BusinessPartner] ([UserName],[Name],[Id]) VALUES ('washi','washi','69aacf26-300e-477b-b9a6-408324ca1cad');
-INSERT INTO [dbo].[OrigamUser] ([UserName],[IsLockedOut],[EmailConfirmed],[refBusinessPartnerId],[Password],[Id],[FailedPasswordAttemptCount],[Is2FAEnforced]) VALUES ('washi',1,1,'69aacf26-300e-477b-b9a6-408324ca1cad','FA000.AJLuD1q172kAPUnyYGQcS4nDiIIq4nnRgnGM4U4Yc/GwAcHA7nMjEAAe21JTicJQUQ==','f0154207-4f49-476d-b955-6f587dd61708',0,0);
-INSERT INTO [dbo].[BusinessPartnerOrigamRole] ([Id],[refBusinessPartnerId],[refOrigamRoleId]) VALUES ('d8130a52-a52c-49bb-b80d-565fa5b9eb21','69aacf26-300e-477b-b9a6-408324ca1cad','E0AD1A0B-3E05-4B97-BE38-12FF63E7F2F2');
-UPDATE [dbo].[OrigamParameters] SET [BooleanValue] = 1 WHERE [Id] = 'e42f864f-5018-4967-abdc-5910439adc9a'
+﻿INSERT INTO [BusinessPartner] ([UserName],[Name],[Id]) VALUES ('washi','washi','69aacf26-300e-477b-b9a6-408324ca1cad');
+INSERT INTO [OrigamUser] ([UserName],[IsLockedOut],[EmailConfirmed],[refBusinessPartnerId],[Password],[Id],[FailedPasswordAttemptCount],[Is2FAEnforced]) VALUES ('washi',1,1,'69aacf26-300e-477b-b9a6-408324ca1cad','FA000.AJLuD1q172kAPUnyYGQcS4nDiIIq4nnRgnGM4U4Yc/GwAcHA7nMjEAAe21JTicJQUQ==','f0154207-4f49-476d-b955-6f587dd61708',0,0);
+INSERT INTO [BusinessPartnerOrigamRole] ([Id],[refBusinessPartnerId],[refOrigamRoleId]) VALUES ('d8130a52-a52c-49bb-b80d-565fa5b9eb21','69aacf26-300e-477b-b9a6-408324ca1cad','E0AD1A0B-3E05-4B97-BE38-12FF63E7F2F2');
+UPDATE [OrigamParameters] SET [BooleanValue] = 1 WHERE [Id] = 'e42f864f-5018-4967-abdc-5910439adc9a'

--- a/model-tests/model/AutomaticTests/DeploymentVersion/AutomaticTests/1.0.0.origam___commandText___d2e7a99b-340a-4a4f-9097-c8d8561b70da.txt
+++ b/model-tests/model/AutomaticTests/DeploymentVersion/AutomaticTests/1.0.0.origam___commandText___d2e7a99b-340a-4a4f-9097-c8d8561b70da.txt
@@ -1,3 +1,3 @@
 ﻿CREATE PROCEDURE clearScreenConfiguration
 AS
-DELETE FROM [dbo].[OrigamFormPanelConfig];
+DELETE FROM [OrigamFormPanelConfig];

--- a/model-tests/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___95c0c60e-574c-42be-98c1-8ab1ccac9f15.txt
+++ b/model-tests/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___95c0c60e-574c-42be-98c1-8ab1ccac9f15.txt
@@ -1,4 +1,4 @@
-﻿INSERT [dbo].[AsapParameters] ([FloatValue], [StringValue], [DateValue], [BooleanValue], [IntValue],
+﻿INSERT [AsapParameters] ([FloatValue], [StringValue], [DateValue], [BooleanValue], [IntValue],
  [GuidValue], [CurrencyValue], [RecordUpdated], [RecordCreatedServer], [Id], [RecordUpdatedServer],
   [RecordCreatedBy], [RecordCreated], [RecordUpdatedBy]) 
 VALUES (NULL, NULL, NULL, 0, 0, N'00000000-0000-0000-0000-000000000000', 0.0000, NULL, NULL, 

--- a/model-tests/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___bacd2e7b-d380-4bf1-bfe6-05366f277361.txt
+++ b/model-tests/model/Root/DeploymentVersion/_origam_root/1.1.origam___commandText___bacd2e7b-d380-4bf1-bfe6-05366f277361.txt
@@ -1,12 +1,11 @@
-﻿
-CREATE  VIEW [dbo].[BusinessPartnerLookup]
+﻿CREATE VIEW [BusinessPartnerLookup]
 AS
 SELECT
 	cast(BusinessPartner.Name + ISNULL(' ' + BusinessPartner.FirstName, '') + ISNULL(N', ' + ParentBusinessPartner.Name, N'') as nvarchar(1000)) AS LookupText,
 	BusinessPartner.*
 FROM
-	dbo.BusinessPartner BusinessPartner 
-	left outer join dbo.BusinessPartner ParentBusinessPartner
+	BusinessPartner BusinessPartner 
+	left outer join BusinessPartner ParentBusinessPartner
 		ON ParentBusinessPartner.Id = BusinessPartner.ParentId
 
 

--- a/model-tests/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___617ae0bc-c9ea-4dc5-8981-4785fd20424e.txt
+++ b/model-tests/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___617ae0bc-c9ea-4dc5-8981-4785fd20424e.txt
@@ -1,1 +1,1 @@
-﻿GRANT EXEC ON TYPE::[dbo].[AsapListValue] TO [public]
+﻿GRANT EXEC ON TYPE::[AsapListValue] TO [public]

--- a/model-tests/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___cf5652d6-47c7-44c8-9569-54e7719c2806.txt
+++ b/model-tests/model/Root/DeploymentVersion/_origam_root/4.1.origam___commandText___cf5652d6-47c7-44c8-9569-54e7719c2806.txt
@@ -1,4 +1,4 @@
-﻿create type dbo.AsapListValue as TABLE
+﻿create type AsapListValue as TABLE
 (
 	ListValue nvarchar(max) not null
 )

--- a/model-tests/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___01f92cea-3c5a-4abf-ae3a-154cd8d5655c.txt
+++ b/model-tests/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___01f92cea-3c5a-4abf-ae3a-154cd8d5655c.txt
@@ -1,2 +1,1 @@
-﻿
-DROP VIEW [dbo].[BusinessPartnerLookup]
+﻿DROP VIEW [BusinessPartnerLookup]

--- a/model-tests/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___86c0f1c7-80c8-4cb2-a092-a638577f2aaf.txt
+++ b/model-tests/model/Root/DeploymentVersion/_origam_root/4.12.origam___commandText___86c0f1c7-80c8-4cb2-a092-a638577f2aaf.txt
@@ -1,12 +1,11 @@
-﻿
-CREATE  VIEW [dbo].[BusinessPartnerLookup]
+﻿CREATE VIEW [BusinessPartnerLookup]
 AS
 SELECT
 	cast(BusinessPartner.Name + ISNULL(' ' + BusinessPartner.FirstName, '') + ISNULL(N', ' + ParentBusinessPartner.Name, N'') as nvarchar(1000)) AS LookupText,
 	BusinessPartner.*
 FROM
-	dbo.BusinessPartner BusinessPartner 
-	left outer join dbo.BusinessPartner ParentBusinessPartner
+	BusinessPartner BusinessPartner 
+	left outer join BusinessPartner ParentBusinessPartner
 		ON ParentBusinessPartner.Id = BusinessPartner.ParentId
 
 

--- a/model-tests/model/Security/DeploymentVersion/Security/1.1.origam___commandText___7e35fff3-4448-4d73-880f-74f7250b22fc.txt
+++ b/model-tests/model/Security/DeploymentVersion/Security/1.1.origam___commandText___7e35fff3-4448-4d73-880f-74f7250b22fc.txt
@@ -30,7 +30,7 @@ ALTER TABLE BusinessPartnerAsapRole WITH NOCHECK ADD CONSTRAINT
 	FK_BusinessPartnerAsapRole_refAsapRoleId_AsapRole FOREIGN KEY
 	(
 	refAsapRoleId
-	) REFERENCES dbo.AsapRole
+	) REFERENCES AsapRole
 	(
 	Id
 	)

--- a/model-tests/model/Security/DeploymentVersion/Security/5.3.origam___commandText___af575cf0-0c21-4c01-88c5-75b5846e8d05.txt
+++ b/model-tests/model/Security/DeploymentVersion/Security/5.3.origam___commandText___af575cf0-0c21-4c01-88c5-75b5846e8d05.txt
@@ -1,4 +1,4 @@
-﻿CREATE TRIGGER LockOutSynchronizer ON [dbo].[OrigamUser]
+﻿CREATE TRIGGER LockOutSynchronizer ON [OrigamUser]
 	FOR UPDATE
 AS
 
@@ -27,10 +27,10 @@ BEGIN
 			SET @lastLocoutDateValue = NULL
 		END
 
-	    UPDATE [dbo].[OrigamUser]
+	    UPDATE [OrigamUser]
 			SET LastLockoutDate = @lastLocoutDateValue
-		FROM [dbo].[OrigamUser]
-		INNER JOIN INSERTED i on i.Id = [dbo].[OrigamUser].Id
+		FROM [OrigamUser]
+		INNER JOIN INSERTED i on i.Id = [OrigamUser].Id
 	END
 
 	ELSE 
@@ -53,10 +53,10 @@ BEGIN
 				SET @IsLockedOutValue = 1
 			END
 
-			UPDATE [dbo].[OrigamUser]
+			UPDATE [OrigamUser]
 				SET IsLockedOut =  @IsLockedOutValue
-			FROM [dbo].[OrigamUser]
-			INNER JOIN INSERTED i on i.Id = [dbo].[OrigamUser].Id
+			FROM [OrigamUser]
+			INNER JOIN INSERTED i on i.Id = [OrigamUser].Id
 		END
 	END
 END

--- a/test/startTests.sh
+++ b/test/startTests.sh
@@ -12,7 +12,7 @@ fi
 export ASPNETCORE_URLS="http://+:8080"
 dotnet Origam.Server.dll &
 echo "TEST DB Connection"
-DATAOUT=$(dotnet origam-utils.dll test-db -t 5 -d 5000 -c "SELECT 1 FROM dbo.\"OrigamModelVersion\" where \"refSchemaExtensionId\"='${OrigamSettings_SchemaExtensionGuid}'")
+DATAOUT=$(dotnet origam-utils.dll test-db -t 5 -d 5000 -c "SELECT 1 FROM \"OrigamModelVersion\" where \"refSchemaExtensionId\"='${OrigamSettings_SchemaExtensionGuid}'")
 if [[ "$DATAOUT" != True ]]; then
 echo "Database connection failed";
 exit 1;

--- a/test/tests_e2e/DataBaseData/clearScreenConfiguration.sql
+++ b/test/tests_e2e/DataBaseData/clearScreenConfiguration.sql
@@ -1,3 +1,3 @@
 CREATE PROCEDURE clearScreenConfiguration
 AS
-DELETE FROM [dbo].[OrigamFormPanelConfig];
+DELETE FROM [OrigamFormPanelConfig];


### PR DESCRIPTION
https://community.origam.com/t/deployment-script-generator-error-when-same-tables-in-different-schemas-exist/1278