### PR TITLE
FIX: Search results were not cleared after closing the search window

### DIFF
--- a/frontend-html/src/model/entities/Searcher.ts
+++ b/frontend-html/src/model/entities/Searcher.ts
@@ -351,6 +351,7 @@ export class Searcher implements ISearcher {
     this.workQueueResultGroup = undefined;
     this.chatResultGroup = undefined;
     this.searchTerm = "";
+    this.selectedResult = undefined;
   }
 }
 


### PR DESCRIPTION
pressing enter in empty search input opened the last search result