### PR TITLE
Fix of Origam Architect for PostgresSql: (#730)

### DIFF
--- a/backend/Origam.DA.Service/MsSqlDataService.cs
+++ b/backend/Origam.DA.Service/MsSqlDataService.cs
@@ -566,10 +566,10 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0, 0)",
         public override string CreateOrigamUserInsert(QueryParameterCollection parameters)
         {
             return string.Format("INSERT INTO [dbo].[OrigamUser] " +
-                "([UserName],[IsLockedOut],[EmailConfirmed],[refBusinessPartnerId],[Password],[Id],[FailedPasswordAttemptCount],[Is2FAEnforced]) " +
-                "VALUES ('{0}',{1},{2},'{3}','{4}','{5}','{6}','{7}')", 
+                "([UserName],[EmailConfirmed],[refBusinessPartnerId],[Password],[Id],[FailedPasswordAttemptCount],[Is2FAEnforced]) " +
+                "VALUES ('{0}',{1},'{2}','{3}','{4}','{5}','{6}')", 
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "UserName").Select(param => param.Value).FirstOrDefault(),
-                1,1,
+                1,
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "Id").Select(param => param.Value).FirstOrDefault(),
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "Password").Select(param => param.Value).FirstOrDefault(),
                Guid.NewGuid().ToString(),0,0);

--- a/backend/Origam.DA.Service/PgSqlDataService.cs
+++ b/backend/Origam.DA.Service/PgSqlDataService.cs
@@ -183,8 +183,8 @@ namespace Origam.DA.Service
 
         public override void DeleteUser(string user,bool DatabaseIntegratedAuthentication)
         {
-            //change owner of object  to postgres. it is not good , but for testing is ok.
-            ExecuteUpdate(string.Format("REASSIGN OWNED BY \"{0}\" TO postgres", user), null);
+            // Changing the ownership to user configured for connecting the database to allow delete new role.
+            ExecuteUpdate(string.Format("REASSIGN OWNED BY \"{0}\" TO CURRENT_USER", user), null);
             ExecuteUpdate(string.Format("DROP OWNED BY \"{0}\" ", user), null);
             ExecuteUpdate(string.Format("DROP ROLE \"{0}\" ", user), null);
         }
@@ -196,6 +196,7 @@ namespace Origam.DA.Service
         {
             CheckDatabaseName(name);
             ExecuteUpdate(string.Format("DROP DATABASE \"{0}\"", name), null);
+
         }
 
         public override void CreateDatabase(string name)
@@ -494,10 +495,10 @@ group by ccu.table_name,tc.table_name,tc.constraint_name,tc.table_schema ";
 
         public override string CreateOrigamUserInsert(QueryParameterCollection parameters)
         {
-            return string.Format("INSERT INTO \"OrigamUser\" (\"UserName\",\"IsLockedOut\",\"EmailConfirmed\",\"refBusinessPartnerId\",\"Password\",\"Id\",\"FailedPasswordAttemptCount\",\"Is2FAEnforced\") " +
-                "VALUES ('{0}',{1},{2},'{3}','{4}','{5}','{6}','{7}')",
+            return string.Format("INSERT INTO \"OrigamUser\" (\"UserName\",\"EmailConfirmed\",\"refBusinessPartnerId\",\"Password\",\"Id\",\"FailedPasswordAttemptCount\",\"Is2FAEnforced\") " +
+                "VALUES ('{0}',{1},'{2}','{3}','{4}','{5}','{6}')",
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "UserName").Select(param => param.Value).FirstOrDefault(),
-                "true", "true",
+                "true",
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "Id").Select(param => param.Value).FirstOrDefault(),
                 parameters.Cast<QueryParameter>().Where(param => param.Name == "Password").Select(param => param.Value).FirstOrDefault(),
                 Guid.NewGuid().ToString(),0,"false");

--- a/backend/OrigamArchitect/App.config
+++ b/backend/OrigamArchitect/App.config
@@ -95,7 +95,15 @@
       <appender-ref ref="ConsoleAppender"/>
     </logger>
   </log4net>
-  <system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+    <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">
       <providers>
         <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri=""/>

--- a/backend/OrigamSetup/ArchitectSetup.wxs
+++ b/backend/OrigamSetup/ArchitectSetup.wxs
@@ -49,6 +49,34 @@
               <File Id="ORIGAMARCHITECT.EXE.CONFIG" Name="OrigamArchitect.exe.config" Source="config\OrigamArchitect.exe.config">
               </File>
             </Component>
+            <Component Id="SYSTEM.NUMERICS.VECTORS.DLL" DiskId="1" Guid="EB813AD1-20C7-4F31-99B1-1D330FF9EC40">
+              <File Id="SYSTEM.NUMERICS.VECTORS.DLL" Name="System.Numerics.Vectors.dll" Source="source\System.Numerics.Vectors.dll">
+              </File>
+            </Component>
+            <Component Id="SYSTEM.THREADING.CHANNELS.DLL" DiskId="1" Guid="A0EB56E0-0EA3-43E6-B2C6-BC846DB50526">
+              <File Id="SYSTEM.THREADING.CHANNELS.DLL" Name="System.Threading.Channels.dll" Source="source\System.Threading.Channels.dll">
+              </File>
+            </Component>
+            <Component Id="MICROSOFT.BCL.ASYNCINTERFACES.DLL" DiskId="1" Guid="DB51BAB9-8AE7-4B69-9F51-FEC7AE1363C5">
+              <File Id="MICROSOFT.BCL.ASYNCINTERFACES.DLL" Name="Microsoft.Bcl.AsyncInterfaces.dll" Source="source\Microsoft.Bcl.AsyncInterfaces.dll">
+              </File>
+            </Component>
+            <Component Id="MICROSOFT.BCL.HASHCODE.DLL" DiskId="1" Guid="10A69F47-6A2F-4840-AC5E-DB24F734834F">
+              <File Id="MICROSOFT.BCL.HASHCODE.DLL" Name="Microsoft.Bcl.HashCode.dll" Source="source\Microsoft.Bcl.HashCode.dll">
+              </File>
+            </Component>
+            <Component Id="SYSTEM.TEXT.JSON.DLL" DiskId="1" Guid="E3F2FBF8-8D0A-4FEB-9FC3-76707B86AB4E">
+              <File Id="SYSTEM.TEXT.JSON.DLL" Name="System.Text.Json.dll" Source="source\System.Text.Json.dll">
+              </File>
+            </Component>
+            <Component Id="SYSTEM.DIAGNOSTICS.DIAGNOSTICSOURCE.DLL" DiskId="1" Guid="8315A8AE-BA6B-4D8E-B02B-79B5B477A315">
+              <File Id="SYSTEM.DIAGNOSTICS.DIAGNOSTICSOURCE.DLL" Name="System.Diagnostics.DiagnosticSource.dll" Source="source\System.Diagnostics.DiagnosticSource.dll">
+              </File>
+            </Component>
+            <Component Id="ORIGAM.EXCEL.DLL" DiskId="1" Guid="32F0928A-4B26-4A4B-AB80-3564E8AF13A8">
+              <File Id="ORIGAM.EXCEL.DLL" Name="Origam.Excel.dll" Source="source\Origam.Excel.dll">
+              </File>
+            </Component>
             <Component Id="AEROWIZARD.DLL" DiskId="1" Guid="401981CE-043E-4428-A8C4-6C10FBCA893F">
               <File Id="AEROWIZARD.DLL" Name="AeroWizard.dll" Source="source\AeroWizard.dll">
               </File>
@@ -639,6 +667,13 @@
       </ComponentRef>
       <ComponentRef Id="StartMenuShortcuts">
       </ComponentRef>
+      <ComponentRef Id="SYSTEM.NUMERICS.VECTORS.DLL"></ComponentRef>
+      <ComponentRef Id="SYSTEM.THREADING.CHANNELS.DLL"></ComponentRef>
+      <ComponentRef Id="MICROSOFT.BCL.ASYNCINTERFACES.DLL"></ComponentRef>
+      <ComponentRef Id="MICROSOFT.BCL.HASHCODE.DLL"></ComponentRef>
+      <ComponentRef Id="SYSTEM.TEXT.JSON.DLL"></ComponentRef>
+      <ComponentRef Id="SYSTEM.DIAGNOSTICS.DIAGNOSTICSOURCE.DLL"></ComponentRef>
+      <ComponentRef Id="ORIGAM.EXCEL.DLL"></ComponentRef>
       <ComponentRef Id="AEROWIZARD.DLL">
       </ComponentRef>
       <ComponentRef Id="ANTLR3.RUNTIME.DLL">

--- a/backend/OrigamSetup/build-msi.bat
+++ b/backend/OrigamSetup/build-msi.bat
@@ -1,0 +1,1 @@
+powershell ./build-msi.ps1 -PRODUCT_VERSION 100.1.0.1 -PRODUCT_NUMBER 100.1.0.1-Test

--- a/backend/OrigamSetup/build-msi.ps1
+++ b/backend/OrigamSetup/build-msi.ps1
@@ -1,0 +1,10 @@
+# Build OrigamSetup.msi locally
+# Example of use: powershell ./prepareSetup.ps1 -PRODUCT_VERSION 100.1.0.1 -PRODUCT_NUMBER 100.1.0.1-Test
+
+param([Parameter(Mandatory=$true)] $PRODUCT_NUMBER, [Parameter(Mandatory=$true)] $PRODUCT_VERSION)
+$WIX="c:\Program Files (x86)\WiX Toolset v3.11\"
+
+(Get-Content ArchitectSetup.wxs).replace("@product_version@", "$($PRODUCT_VERSION)").replace("@branch@", "$($PRODUCT_NUMBER)") | Set-Content ArchitectSetup-$($PRODUCT_VERSION).wxs
+
+& "$($WIX)bin\candle.exe" -ext WixSqlExtension -ext WixUtilExtension ArchitectSetup-$($PRODUCT_VERSION).wxs
+& "$($WIX)bin\light.exe" -ext WixSqlExtension -ext WixUtilExtension -ext WixNetFxExtension -sice:ICE20 -cultures:en-us -loc resources.en-us.wxl -out OrigamSetup.msi ArchitectSetup-$($PRODUCT_VERSION).wixobj

--- a/backend/OrigamSetup/config/OrigamArchitect.exe.config
+++ b/backend/OrigamSetup/config/OrigamArchitect.exe.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<configSections>
 		<section name="enterpriselibrary.configurationSettings" type="Microsoft.Practices.EnterpriseLibrary.Configuration.ConfigurationManagerSectionHandler, Microsoft.Practices.EnterpriseLibrary.Configuration" />
@@ -61,6 +61,12 @@
     </logger>
   </log4net>
   <runtime>
+   <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+     <dependentAssembly>
+       <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+       <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" /> 
+     </dependentAssembly>
+   </assemblyBinding>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
     <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>


### PR DESCRIPTION
* Fix of Origam Architect:

1. Postgresql => Create New Project on PostgresSQL database terminated in ERROR:

https://community.origam.com/t/origam-architect-create-new-project-with-postgressql-database-fail-on-missing-system-numeric-vectors-dll/1735/6

    * By fixing this issue, I have found on my local postgresql installation that user <dbname> which has been created by installation is not removed in case if the create new project fails (rollback didn't work because in my database there was no user postgres). I fixed this by updating a script for rollback.

2. Postges + MS SQL:

    * New project could not be created because of failing step **Create new Web User** => there was remove of column `IsLockedOut` column in the model but this column remained in `CreateOrigamUserInsert` in both adapters - MS SQL and Postgres

Note:

I included powershell script for local wix testing => build-msi.ps1 and build-msi.bat to run it with specific parameters.

* #730 - https://github.com/origam/origam/pull/730

https://community.origam.com/t/origam-architect-create-new-project-with-postgressql-database-fail-on-missing-system-numeric-vectors-dll/1735

- Removing comments as requested by washibana