### PR TITLE
FIX: Custom date field format was used even when the AsDateBox "Forma…

### DIFF
--- a/backend/Origam.OrigamEngine/ModelXmlBuilders/DateBoxBuilder.cs
+++ b/backend/Origam.OrigamEngine/ModelXmlBuilders/DateBoxBuilder.cs
@@ -35,7 +35,7 @@ namespace Origam.OrigamEngine.ModelXmlBuilders
 			string pattern;
 			CultureInfo culture = CultureInfo.CurrentCulture;
 
-			if(customFormat != null && customFormat != String.Empty)
+			if(format == "Custom" && !string.IsNullOrEmpty(customFormat))
 			{
 				switch(customFormat)
 				{


### PR DESCRIPTION
…t" property was not set to "Custom"