### PR TITLE
FIX: Architect editors open in tabs were closed after clicking on lin…

### DIFF
--- a/backend/Origam.Workbench/Commands/SchemaCommands.cs
+++ b/backend/Origam.Workbench/Commands/SchemaCommands.cs
@@ -553,7 +553,7 @@ namespace Origam.Workbench.Commands
 			}
             else if (item is EntityUIAction)
             {
-               editor = new UiActionEditor();
+               editor = new UiActionEditor(ShowDialog);
             }
             else if (itemType == "Origam.Schema.WorkflowModel.Workflow" && ! ShowDialog)
             {
@@ -566,14 +566,14 @@ namespace Origam.Workbench.Commands
                 }
                 else
                 {
-                    editor = new PropertyGridEditor();
                     this.ShowDialog = true;
+                    editor = new PropertyGridEditor(ShowDialog);
                     this.ShowDiagramEditorAfterSave = true;
                 }
             }
             else
 			{
-                editor = new PropertyGridEditor();
+                editor = new PropertyGridEditor(ShowDialog);
             }
 
             // Set editor to dirty, if object has not been persisted, yet (new item)

--- a/backend/Origam.Workbench/Editors/PropertyGridEditor.cs
+++ b/backend/Origam.Workbench/Editors/PropertyGridEditor.cs
@@ -29,11 +29,19 @@ namespace Origam.Workbench.Editors
 {
 	public class PropertyGridEditor : AbstractEditor
     {
-        private PropertyGridEx propertyGrid1;
+	    private readonly bool closeOnLinkClick;
+	    private PropertyGridEx propertyGrid1;
 
         private void InitializeComponent()
 		{
-            this.propertyGrid1 = new PropertyGridEx(Close);
+            this.propertyGrid1 = new PropertyGridEx();
+            propertyGrid1.LinkClicked += (sender, args) =>
+            {
+	            if (closeOnLinkClick)
+	            {
+					Close();
+	            }
+            };
             this.SuspendLayout();
             // 
             // propertyGrid1
@@ -62,8 +70,9 @@ namespace Origam.Workbench.Editors
 
 		}
 
-        public PropertyGridEditor()
+        public PropertyGridEditor(bool closeOnLinkClick)
 		{
+			this.closeOnLinkClick = closeOnLinkClick;
 			InitializeComponent();
             this.ContentLoaded += new EventHandler(PropertyGridEditor_ContentLoaded);
 			this.BackColor = OrigamColorScheme.FormBackgroundColor;

--- a/backend/Origam.Workbench/Editors/UiActionEditor.cs
+++ b/backend/Origam.Workbench/Editors/UiActionEditor.cs
@@ -30,6 +30,10 @@ namespace Origam.Workbench.Editors
 {
     class UiActionEditor: PropertyGridEditor
     {
+        public UiActionEditor(bool closeOnLinkClick) : base(closeOnLinkClick)
+        {
+        }
+
         public override List<ToolStrip> GetToolStrips(int maxWidth = -1)
         {
             if (!showMenusInAppToolStrip) return new List<ToolStrip>();

--- a/backend/Origam.Workbench/PropertyGrid/PropertyGridEx.cs
+++ b/backend/Origam.Workbench/PropertyGrid/PropertyGridEx.cs
@@ -45,12 +45,7 @@ namespace Origam.Workbench.PropertyGrid
         private static readonly Image UIItemEditImage =
             Properties.Resources.Editor_8x;
 
-        private readonly Action closeWindow;
-
-        public PropertyGridEx(Action closeWindow): this()
-        {
-            this.closeWindow = closeWindow;
-        }
+        public event EventHandler LinkClicked;
 
         public PropertyGridEx()
         {
@@ -80,7 +75,9 @@ namespace Origam.Workbench.PropertyGrid
             var element = propDesc.GetValue(context.Instance) as AbstractSchemaItem;
             if (element != null)
             {
-                var editHandler = new ModelElementEditHandler(closeWindow);
+                var editHandler = new ModelElementEditHandler();
+                editHandler.LinkClicked += (sender, args) =>
+                    LinkClicked?.Invoke(this, EventArgs.Empty);
                 valueUIItemList.Add(new
                     PropertyValueUIItem(UIItemEditImage,
                     editHandler.Run, "Double click to open " + element.Path));
@@ -89,12 +86,7 @@ namespace Origam.Workbench.PropertyGrid
 
         class ModelElementEditHandler
         {
-            private readonly Action closeWindow;
-
-            public ModelElementEditHandler(Action closeWindow)
-            {
-                this.closeWindow = closeWindow;
-            }
+            public event EventHandler LinkClicked;
 
             public void Run(ITypeDescriptorContext context,
                 PropertyDescriptor descriptor, PropertyValueUIItem invokedItem)
@@ -110,7 +102,7 @@ namespace Origam.Workbench.PropertyGrid
                     EditSchemaItem cmdEdit = new Commands.EditSchemaItem();
                     cmdEdit.Owner = descriptor.GetValue(context.Instance);
                     cmdEdit.Run();
-                    closeWindow?.Invoke();
+                    LinkClicked?.Invoke(this, EventArgs.Empty);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
…k icons inside

only editors open in pop-ups should be closed after clinking on a link