### PR TITLE
#2529 Fix cloning process when creating a WQ from entity

### DIFF
--- a/backend/Origam.Schema.WorkflowModel/WorkflowHelper.cs
+++ b/backend/Origam.Schema.WorkflowModel/WorkflowHelper.cs
@@ -186,13 +186,13 @@ namespace Origam.Schema.WorkflowModel
 			wqStructure.ClearCacheOnPersist = false;
 			wqStructure.ThrowEventOnPersist = false;
 			wqStructure.Persist();
+			wqStructure.UpdateReferences();
+			wqStructure.ClearCacheOnPersist = true;
 			DataStructureSortSet sortSet = EntityHelper.CreateSortSet(
 				wqStructure, "Default", true);
 			EntityHelper.CreateSortSetItem(sortSet,
 				wqStructure.Entities[0] as DataStructureEntity, "RecordCreated",
 				DataStructureColumnSortDirection.Ascending, true);
-			wqStructure.UpdateReferences();
-			wqStructure.ClearCacheOnPersist = true;
 			wqStructure.ThrowEventOnPersist = true;
 			wqStructure.Persist();
 


### PR DESCRIPTION
A persisting of a new sort set and sort set item caused model item cache invalidation and removal of field OldPrimaryKey. The field is crucial for a corret run of UpdateReference() after cloning.