### PR TITLE
The .NET SDK no longer generates the runtimeconfig.dev.json file by d…

### DIFF
--- a/backend/Origam.Server/Origam.Server.csproj
+++ b/backend/Origam.Server/Origam.Server.csproj
@@ -5,6 +5,7 @@
     <UserSecretsId>8a03936d-700c-4edd-9ffa-e3df428dc822</UserSecretsId>
     <TypeScriptToolsVersion>3.1</TypeScriptToolsVersion>
     <LangVersion>7.1</LangVersion>
+	<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
…efault.