### PR TITLE
FIX: Filter UI conflict with add/copy row

### DIFF
--- a/frontend-html/src/model/actions-ui/DataView/onCopyRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onCopyRowClick.ts
@@ -46,18 +46,10 @@ export function onCopyRowClick(ctx: any, switchToFormPerspective?: boolean) {
       if(switchToFormPerspective){
         dataView.activateFormView?.({saveNewState: false});
       }
-      hideFilters(ctx, event);
       yield*formScreenLifecycle.onCopyRow(entity, gridId, selectedRowId);
     } catch (e) {
       yield*handleError(ctx)(e);
       throw e;
     }
   });
-}
-
-function hideFilters(ctx: any, event: any){
-  const filterConfiguration = getFilterConfiguration(ctx);
-  if(filterConfiguration.isFilterControlsDisplayed){
-    filterConfiguration.onFilterDisplayClick(event);
-  }
 }

--- a/frontend-html/src/model/actions-ui/DataView/onCreateRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onCreateRowClick.ts
@@ -42,8 +42,6 @@ export function onCreateRowClick(ctx: any, switchToFormPerspective?: boolean) {
       if(switchToFormPerspective){
         dataView.activateFormView?.({saveNewState: false});
       }
-      const filterConfiguration = getFilterConfiguration(ctx);
-      filterConfiguration.clearFilters();
       yield*formScreenLifecycle.onCreateRow(entity, gridId);
     } catch (e) {
       yield*handleError(ctx)(e);

--- a/frontend-html/src/model/entities/FilterConfiguration.ts
+++ b/frontend-html/src/model/entities/FilterConfiguration.ts
@@ -90,6 +90,11 @@ export class FilterConfiguration implements IFilterConfiguration {
 
   filteringFunction(ignorePropertyId?: string): (row: any[]) => boolean {
     return (row: any[]) => {
+      const dataTable = getDataTable(this);
+      const dirtyValues = dataTable.getDirtyValues(row);
+      if (dirtyValues.size > 0){
+        return true;
+      }
       if (!this.isPresentInDetail(row)) {
         return false;
       }


### PR DESCRIPTION
…ers were active led to filters to be closed and grid to be reloaded

which caused active row to be switched to the first row because the dirty row was not returned by the GetRows call. This caused an error on the server.