### PR TITLE
FIX: Column width was not saved

### DIFF
--- a/backend/Origam.OrigamEngine/ModelXmlBuilders/FormXmlBuilder.cs
+++ b/backend/Origam.OrigamEngine/ModelXmlBuilders/FormXmlBuilder.cs
@@ -1786,13 +1786,11 @@ namespace Origam.OrigamEngine.ModelXmlBuilders
 									.ExtendedProperties["OrigamDataType"]));
 								break;
 						}
-
-						// copy all attributes to the displayed primary key column
+						
 						XmlElement zeroColumn = propertiesElement.FirstChild as XmlElement;
 						if(propertyElement.GetAttribute("Id") == zeroColumn.GetAttribute("Id"))
 						{
-							XmlNode clone = propertyElement.CloneNode(true);
-							propertiesElement.ReplaceChild(clone, zeroColumn);
+							propertiesElement.RemoveChild(zeroColumn);
 						}
 						if(csi.MultiColumnAdapterFieldCondition != Guid.Empty)
 						{


### PR DESCRIPTION
If there was a column with Id "Id" in a grid and the user edited its width, it was not saved because the column was duplicated in the screen XML (initUi)