### PR TITLE
FIX: AxiosError was shown to the user

### DIFF
--- a/frontend-html/src/model/actions/handleError.tsx
+++ b/frontend-html/src/model/actions/handleError.tsx
@@ -32,7 +32,7 @@ export function handleError(ctx: any) {
       // finished (RowStates for example)
       return;
     }
-    if(error.code === "ERR_NETWORK" && error.name === "AxiosError"){
+    if (error.code === "ERR_NETWORK" && error.name === "AxiosError"){
       yield*selectors.error.getDialogController(ctx).pushError(
         T(
           "Network Unavailable",

--- a/frontend-html/src/model/actions/handleError.tsx
+++ b/frontend-html/src/model/actions/handleError.tsx
@@ -32,6 +32,15 @@ export function handleError(ctx: any) {
       // finished (RowStates for example)
       return;
     }
+    if(error.code === "ERR_NETWORK" && error.name === "AxiosError"){
+      yield*selectors.error.getDialogController(ctx).pushError(
+        T(
+          "Network Unavailable",
+          "network_unavailable"
+        )
+      );
+      return;
+    }
     if (error.response &&
         error.response.status === 404 &&
         error.response.data.message.includes("Origam.Server.RowNotFoundException")) {


### PR DESCRIPTION
I found an unused localization string "network_unavailable": "Network Unavailable" so I used it. I would probably use a different formulation, but since this one was ok before I guess it is ok now. @tvavrda Is it ok?