### PR TITLE
Identity GUI

### DIFF
--- a/backend/Origam.Server/Views/Shared/_Layout.cshtml
+++ b/backend/Origam.Server/Views/Shared/_Layout.cshtml
@@ -26,9 +26,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@string.Format(SharedLocalizer.GetString("IdentityServerTitle"), settings.TitleText )</title>
-    <link rel="stylesheet" href="~/assets/identity/css/css.css" />
-    <link rel="stylesheet" href="~/assets/identity/css/main.css" />
-    <link rel="stylesheet" href="~/assets/identity/css/login.css" />
+    <link rel="stylesheet" href="~/assets/identity/css/css.css?version=0.0.0.0" />
+    <link rel="stylesheet" href="~/assets/identity/css/main.css?version=0.0.0.0" />
+    <link rel="stylesheet" href="~/assets/identity/css/login.css?version=0.0.0.0" />
 </head>
 <body>
 
@@ -39,8 +39,8 @@
     @RenderBody()
 </div>
 
-<script src="~/assets/identity/js/form-sumbit.js"></script>
-<script src="~/assets/identity/js/custom.js"></script>
+<script src="~/assets/identity/js/form-sumbit.js?version=0.0.0.0"></script>
+<script src="~/assets/identity/js/custom.js?version=0.0.0.0"></script>
 @RenderSection("scripts", required: false)
 </body>
 </html>

--- a/build/build-monorepo.yaml
+++ b/build/build-monorepo.yaml
@@ -80,6 +80,7 @@ jobs:
         (Get-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Controller\AboutController.cs") -replace "ServerVersion Placeholder to be changed at build time", "$(VERSION_NUMBER)" | Set-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Controller\AboutController.cs"
         (Get-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Controller\AboutController.cs") -replace "LinkToCommit Placeholder to be changed at build time", "https://github.com/origam/origam/commit/$(ORIGAM_ORIGAM_COMMIT_ID)" | Set-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Controller\AboutController.cs"
         (Get-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Controller\AboutController.cs") -replace "CommitId Placeholder to be changed at build time", "$(ORIGAM_ORIGAM_COMMIT_ID)" | Set-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Controller\AboutController.cs"
+        (Get-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Views\Shared\_Layout.cshtml") -replace "0.0.0.0", "$(VERSION_NUMBER)" | Set-Content "$(Agent.BuildDirectory)\s\backend\Origam.Server\Views\Shared\_Layout.cshtml"
        displayName: 'Build Number'
      - task: VSBuild@1
        displayName: 'Build architect'


### PR DESCRIPTION
- static files are requested with version parameter, where version id is equal to build id, in order to prevent problems with caching static files between versions