### PR TITLE
FIX: IdentityServiceAgent methods not available in work queues (#1351)

### DIFF
--- a/backend/Origam.Security.Identity/IdentityServiceAgent.cs
+++ b/backend/Origam.Security.Identity/IdentityServiceAgent.cs
@@ -31,11 +31,13 @@ using Origam.Service.Core;
 
 namespace Origam.Security.Identity
 {
-    public class IdentityServiceAgent : AbstractServiceAgent
+    // class is sealed because of a simplified IDisposable pattern implementation
+    public sealed class IdentityServiceAgent : AbstractServiceAgent, IDisposable
     {
 		protected static readonly ILog log
 			= LogManager.GetLogger(typeof(IdentityServiceAgent));
         private IManager userManager;
+        private IServiceScope serviceScope;
 
         public IdentityServiceAgent()
         {
@@ -45,6 +47,11 @@ namespace Origam.Security.Identity
             userManager = SecurityManager.DIServiceProvider
                 .GetService<Microsoft.AspNetCore.Http.IHttpContextAccessor>()
                 .HttpContext?.RequestServices?.GetService<IManager>();
+            if (userManager == null)
+            {
+                serviceScope = SecurityManager.DIServiceProvider.CreateScope();
+                userManager = serviceScope.ServiceProvider.GetService<IManager>();
+            }
         }
 
         private object result;
@@ -773,6 +780,8 @@ namespace Origam.Security.Identity
             xmlDoc.AppendChild(root);
             return xmlDoc;
         }
+
+        public void Dispose() => serviceScope?.Dispose();        
     }
 
 }

--- a/backend/Origam.Workflow/Tasks/ServiceMethodCallEngineTask.cs
+++ b/backend/Origam.Workflow/Tasks/ServiceMethodCallEngineTask.cs
@@ -88,6 +88,10 @@ namespace Origam.Workflow.Tasks
 			{
 				OnFinished(new WorkflowEngineTaskEventArgs(exception));
 			}
+			if (ServiceAgent is IDisposable disposableServiceAgent)
+			{
+				disposableServiceAgent.Dispose();
+			}
 		}
 		private void OnAsyncAgentOnAsyncCallFinished(object sender, AsyncReturnValues args)
 		{


### PR DESCRIPTION
* FIX: IdentityServiceAgent methods didn't work from workflows triggered from automatic work queue processing
* INTERNAL: Simplify IDisposable pattern for IdentityServiceAgent
* INTERNAL: Refactoring

---------

Co-authored-by: Vaclav Urbanek <vaclav.urbanek@advantages.cz>