### PR TITLE
DEV: DeepLinkController

### DIFF
--- a/backend/Origam.Server/Controller/DeepLinkController.cs
+++ b/backend/Origam.Server/Controller/DeepLinkController.cs
@@ -113,10 +113,10 @@ namespace Origam.Server.Controller
         {
             return RunWithErrorHandler(() => Ok(GetMenuId(
                 deepLinkCategory: input.Category,
-                ReferenceId: input.ReferenceId))
+                referenceId: input.ReferenceId))
             );
         }
-        private string GetMenuId(string deepLinkCategory, Guid ReferenceId)
+        private string GetMenuId(string deepLinkCategory, object referenceId)
         {
             DeepLinkCategory linkCategory = GetCategory(deepLinkCategory);
             if (linkCategory == null)
@@ -126,8 +126,8 @@ namespace Origam.Server.Controller
 
             return (ServiceManager.Services
                 .GetService<IDataLookupService>()
-                .GetMenuBinding(linkCategory.LookupId, ReferenceId)
-                ?? throw new Exception($"deepLinkCategory: \"{deepLinkCategory}\" or ReferenceId: \"{ReferenceId}\" was not found"))
+                .GetMenuBinding(linkCategory.LookupId, referenceId)
+                ?? throw new Exception($"deepLinkCategory: \"{deepLinkCategory}\" or ReferenceId: \"{referenceId}\" was not found"))
                 .MenuId;
         }
         private IActionResult GetObjets(string categoryId, int limit, int pageNumber, string searchPhrase)

--- a/backend/Origam.Server/Model/DeepLink/GetDeepLinkMenuInput.cs
+++ b/backend/Origam.Server/Model/DeepLink/GetDeepLinkMenuInput.cs
@@ -24,6 +24,6 @@ namespace Origam.Server.Model.DeepLink
     public class GetDeepLinkMenuInput
     {
         public string Category { get; set; }
-        public Guid ReferenceId { get; set; }
+        public object ReferenceId { get; set; }
     }
 }


### PR DESCRIPTION
* GetDeepLinkMenuInput.ReferenceId type changed from Guid to object, because it was limiting underlying calls to IDataLookupService.GetMenuBinding.
* Fixed letter case of argument name.