### PR TITLE
Fixed: error LGHT0103

### DIFF
--- a/backend/OrigamSetup/ArchitectSetup.wxs
+++ b/backend/OrigamSetup/ArchitectSetup.wxs
@@ -431,14 +431,14 @@
             <Directory Id="lib" Name="lib">
               <Directory Id="win32" Name="win32">
                 <Directory Id="dir_x64" Name="x64">
-                  <Component Id="GIT2_106A5F2.DLL_X64" DiskId="1" Guid="952BFB96-FF27-4DBF-A56D-BAACD0A06CA9">
-                    <File Id="GIT2_106A5F2.DLL_X64" Name="git2-106a5f2.dll" Source="source\lib\win32\x64\git2-106a5f2.dll">
+                  <Component Id="GIT2-E632535.DLL_X64" DiskId="1" Guid="952BFB96-FF27-4DBF-A56D-BAACD0A06CA9">
+                    <File Id="GIT2-E632535.DLL_X64" Name="git2-e632535.dll" Source="source\lib\win32\x64\git2-e632535.dll">
                     </File>
                   </Component>
                 </Directory>
                 <Directory Id="dir_x86" Name="x86">
-                  <Component Id="GIT2_106A5F2.DLL_X86" DiskId="1" Guid="D138CE85-CBB7-4894-BAFF-FE7F6F768463">
-                    <File Id="GIT2_106A5F2.DLL_X86" Name="git2-106a5f2.dll" Source="source\lib\win32\x86\git2-106a5f2.dll">
+                  <Component Id="GIT2-E632535.DLL_X86" DiskId="1" Guid="D138CE85-CBB7-4894-BAFF-FE7F6F768463">
+                    <File Id="GIT2-E632535.DLL_X86" Name="git2-e632535.dll" Source="source\lib\win32\x86\git2-e632535.dll">
                     </File>
                   </Component>
                 </Directory>


### PR DESCRIPTION
 The system cannot find the file 'source\lib\win32\x64\git2-106a5f2.dll'.