### PR TITLE
FIX: AS:ResourceIdByActiveProfile() throws object reference not set

### DIFF
--- a/backend/Origam.Rule/ResourceTools.cs
+++ b/backend/Origam.Rule/ResourceTools.cs
@@ -33,14 +33,9 @@ public interface IResourceTools
 
 public class ResourceTools : IResourceTools
 {
-    public static ResourceTools Instance { get; } = new ();
     private readonly IBusinessServicesService businessService;
     private readonly Func<UserProfile> userProfileGetter;
-
-    private ResourceTools()
-    {
-    }
-
+    
     public ResourceTools(IBusinessServicesService businessService, Func<UserProfile> userProfileGetter)
     {
         this.businessService = businessService;

--- a/backend/Origam.Rule/RuleEngine.cs
+++ b/backend/Origam.Rule/RuleEngine.cs
@@ -65,6 +65,9 @@ namespace Origam.Rule
 		private IDocumentationService _documentationService;
 		private IOrigamAuthorizationProvider _authorizationProvider;
 		private Func<UserProfile> _userProfileGetter;
+		private readonly ResourceTools resourceTools = new(        
+			ServiceManager.Services.GetService<IBusinessServicesService>(), 
+			SecurityManager.CurrentUserProfile); 
 		
 		public static RuleEngine Create(Hashtable contextStores, string transactionId,
 			Guid workflowInstanceId)
@@ -2138,7 +2141,7 @@ namespace Origam.Rule
 					return this.ActiveProfileId();
 
 				case SystemFunction.ResourceIdByActiveProfile:
-					return ResourceTools.Instance.ResourceIdByActiveProfile();
+					return resourceTools.ResourceIdByActiveProfile();
 
 				default:
 					throw new ArgumentOutOfRangeException("Function", functionCall.Function, ResourceUtils.GetString("ErrorUnsupportedFunction"));

--- a/backend/Origam.Rule/XsltFunctions/XsltFunctionContainerFactory.cs
+++ b/backend/Origam.Rule/XsltFunctions/XsltFunctionContainerFactory.cs
@@ -36,8 +36,10 @@ public static class XsltFunctionContainerFactory
     public static IEnumerable<XsltFunctionsDefinition> Create(
         string transactionId = null)
     {
+        var businessServicesService = ServiceManager.Services
+            .GetService<IBusinessServicesService>();
         return Create(
-            ServiceManager.Services.GetService<IBusinessServicesService>(),
+            businessServicesService,
             ServiceManager.Services.GetService<SchemaService>()
                 .GetProvider<XsltFunctionSchemaItemProvider>(),
             ServiceManager.Services.GetService<IPersistenceService>(),
@@ -51,7 +53,9 @@ public static class XsltFunctionContainerFactory
             SecurityManager.CurrentUserProfile,
             XpathEvaluator.Instance,
             HttpTools.Instance,
-            ResourceTools.Instance,
+            new ResourceTools(
+                businessServicesService, 
+                SecurityManager.CurrentUserProfile),
             transactionId);
     }
 

--- a/backend/OrigamArchitect/DebugInfo.cs
+++ b/backend/OrigamArchitect/DebugInfo.cs
@@ -44,7 +44,10 @@ namespace Origam.Workflow
 	public class DebugInfo : IDebugInfoProvider
 	{
 		private IDeploymentService _deployment = null;
-
+		private readonly ResourceTools resourceTools = new ResourceTools(
+			ServiceManager.Services.GetService<IBusinessServicesService>(),
+			SecurityManager.CurrentUserProfile);
+		
 		public DebugInfo()
 		{
 		}
@@ -246,7 +249,7 @@ namespace Origam.Workflow
 			AddHeader("Resource Management Information", result);
 			try
 			{
-				AddInfo("Active Resource Id", ResourceTools.Instance.ResourceIdByActiveProfile(), result);
+				AddInfo("Active Resource Id", resourceTools.ResourceIdByActiveProfile(), result);
 			}
 			catch(Exception ex)
 			{


### PR DESCRIPTION
* Properties did not initialize.
* INTERNAL: ResourceTools refactored it was decided that it would be better to make all dependencies external