### PR TITLE
FIX duplication of action buttons in Origam desktop client

### DIFF
--- a/backend/Origam.Gui.Win/FormGenerator.cs
+++ b/backend/Origam.Gui.Win/FormGenerator.cs
@@ -1485,7 +1485,7 @@ namespace Origam.Gui.Win
 	        UIActionTools.GetValidActions(
 	            formId: (Guid) _formKey["Id"],
 	            panelId: childItem.ControlItem.PanelControlSet.Id,
-	            disableActionButtons: false,
+	            disableActionButtons: panel.DisableActionButtons,
 	            entityId: entityId,
 	            validActions: validActions);
 	        panel.Actions = validActions;


### PR DESCRIPTION
Screen section setting 'DisableActionButtons' was ignored in Origam desktop client.