### PR TITLE
FIX: Color picker rendering flaw

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Editors/ColorEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/ColorEditor.tsx
@@ -107,11 +107,6 @@ export default class ColorEditor extends React.Component<{
                     },
                   ],
                 },
-                /*after: {
-                  100: {
-                    actions: "focusInputField",
-                  },
-                },*/
               },
               OPEN: {
                 entry: "pickValueFromApplied",
@@ -237,6 +232,16 @@ export default class ColorEditor extends React.Component<{
     this.machine.send(evt);
   }
 
+  refTrigger: any;
+  @action.bound setRefTrigger(elm: any) {
+    this.refTrigger = elm;
+  }
+
+  @action.bound refColorDiv(elm: any) {
+    this.refTrigger?.(elm);
+    this.refInput(elm);
+  }
+
   render() {
     return (
       <Dropdowner
@@ -245,63 +250,51 @@ export default class ColorEditor extends React.Component<{
         onDroppedUp={() => this.send({type: "PICKER_DROPPED_UP"})}
         onDroppedDown={() => this.send({type: "PICKER_DROPPED_DOWN"})}
         onOutsideInteraction={() => this.send({type: "PICKER_OUTSIDE_INTERACTION"})}
-        trigger={({refTrigger, setDropped}) => (
-          <div
-            className={S.editorContainer}
-            ref={this.refContainer}
-            style={{
-              zIndex: this.isDroppedDown ? 1000 : undefined,
-            }}
-          >
+        trigger={({ refTrigger, setDropped }) => {
+          this.setRefTrigger(refTrigger);
+          return (
             <div
-              className={S.colorDiv}
-              tabIndex={0}
-              ref={(elm) => {
-                refTrigger(elm);
-                this.refInput(elm);
+              className={S.editorContainer}
+              ref={this.refContainer}
+              style={{
+                zIndex: this.isDroppedDown ? 1000 : undefined,
               }}
-              onMouseDown={() => this.send({type: "DROPDOWN_SYMBOL_MOUSE_DOWN"})}
-              onFocus={() => this.send({type: "INPUT_FIELD_FOCUS"})}
-              onBlur={() => this.send({type: "INPUT_FIELD_BLUR"})}
-              onKeyDown={(event) => this.props.onKeyDown?.(event)}
             >
               <div
-                className={S.colorRect}
-                style={{
-                  backgroundColor:
-                    (this.isDroppedDown ? this.pickedColor : this.appliedValue) || "#000000",
-                }}
+                className={S.colorDiv}
+                tabIndex={0}
+                ref={this.refColorDiv}
+                onMouseDown={() => this.send({type: "DROPDOWN_SYMBOL_MOUSE_DOWN"})}
+                onFocus={() => this.send({type: "INPUT_FIELD_FOCUS"})}
+                onBlur={() => this.send({type: "INPUT_FIELD_BLUR"})}
+                onKeyDown={(event) => this.props.onKeyDown?.(event)}
+              >
+                <div
+                  className={S.colorRect}
+                  style={{
+                    backgroundColor:
+                      (this.isDroppedDown ? this.pickedColor : this.appliedValue) || "#000000",
+                  }}
+                />
+              </div>
+            </div>
+          );
+        }}
+        content={({setDropped}) => (
+            <div
+              tabIndex={0}
+              ref={this.refDroppedPanelContainer}
+              className={S.droppedPanelContainer}
+              onKeyDown={(event: any) => {
+                this.send({type: "PICKER_KEY_DOWN", payload: {event}});
+              }}
+            >
+              <SketchPicker
+                color={this.pickedColor || "#000000"}
+                onChange={this.handleColorChange}
+                disableAlpha={true}
               />
             </div>
-            {/*<input
-              style={{
-                backgroundColor:
-                  ,
-              }}
-              className={S.input}
-              type="text"
-              readOnly={true}
-              onBlur={() => this.send({ type: "INPUT_FIELD_BLUR" })}
-              onFocus={() => this.send({ type: "INPUT_FIELD_FOCUS" })}
-              ref={this.refInput}
-            />*/}
-          </div>
-        )}
-        content={({setDropped}) => (
-          <div
-            tabIndex={0}
-            ref={this.refDroppedPanelContainer}
-            className={S.droppedPanelContainer}
-            onKeyDown={(event: any) => {
-              this.send({type: "PICKER_KEY_DOWN", payload: {event}});
-            }}
-          >
-            <SketchPicker
-              color={this.pickedColor || "#000000"}
-              onChange={this.handleColorChange}
-              disableAlpha={true}
-            />
-          </div>
         )}
       />
     );


### PR DESCRIPTION
This was reported as the ColorPicker was unable to be edited by any input fields in grid view but works correctly in form view.

Further investigations revealed that the field is actually broken in both grid and form views and the main issue is an infinite loop of ColorPicker wasted renders. The exact mechanism of why that only caused the editing issue in grid views and not form views remains unknown, expectation is rather being not properly editable in both, I suspect the difference in details of how the focusing works in grid and form views, which caused any internal color picker input field getting the focus stolen each render in grid view and not in form view.

The infinite loop was present because of an unstable function reference passed to div element. Rough loop description follows:

1. The div element receives new ref reference
2. So the reference gets called.
3. Dropdown's Measure component measured child ref gets called by reference function from previous point.
4. Measure component rerenders its measured content, because its dimensions might have changed.
5. The content contains the div mentioned in pt. 1 closing the loop.

Conclusion points:
1. We shall investigate React rendering performance from time to time. Here "Highlight updates" from React DevTools helped a lot.
2. We shall think twice before directly passing an arrow function to a component prop.
3. Maybe this would not happen if the Measure component is little bit more well-behaved, but here the "think twice about unstable references" point is of much stronger importance, I would not blame the Measure component.

