### PR TITLE
FIX: Save keyboard shortcut didn't persist focused field contents

### DIFF
--- a/frontend-html/src/gui/connections/CScreenToolbar.tsx
+++ b/frontend-html/src/gui/connections/CScreenToolbar.tsx
@@ -52,14 +52,7 @@ import { About } from "model/entities/AboutInfo";
 import { showDialog } from "model/selectors/getDialogStack";
 import { AboutDialog } from "gui/Components/Dialogs/AboutDialog";
 import { geScreenActionButtonsState } from "model/actions-ui/ScreenToolbar/saveBottonVisible";
-
-function isSaveShortcut(event: any) {
-  return event.key === "s" && (event.ctrlKey || event.metaKey);
-}
-
-function isRefreshShortcut(event: any) {
-  return event.key === "r" && (event.ctrlKey || event.metaKey);
-}
+import { isRefreshShortcut, isSaveShortcut } from "utils/keyShortcuts";
 
 @observer
 export class CScreenToolbar extends React.Component<{}> {

--- a/frontend-html/src/model/actions-ui/DataView/TableView/onFieldKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onFieldKeyDown.ts
@@ -28,6 +28,7 @@ import { handleError } from "model/actions/handleError";
 import { getDataView } from "model/selectors/DataView/getDataView";
 import { shouldProceedToChangeRow } from "model/actions-ui/DataView/TableView/shouldProceedToChangeRow";
 import { getGridFocusManager } from "model/entities/GridFocusManager";
+import { isSaveShortcut } from "utils/keyShortcuts";
 
 export function onFieldKeyDown(ctx: any) {
 
@@ -40,6 +41,11 @@ export function onFieldKeyDown(ctx: any) {
     try {
       const dataView = getDataView(ctx);
       const tablePanelView = getTablePanelView(ctx);
+      if( isSaveShortcut(event)){
+        tablePanelView.setEditing(false);
+        yield*flushCurrentRowData(ctx)();
+        return;
+      }
       switch (event.key) {
         case "Tab": {
           if (isGoingToChangeRow(event)) {

--- a/frontend-html/src/utils/keyShortcuts.ts
+++ b/frontend-html/src/utils/keyShortcuts.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2005 - 2023 Advantage Solutions, s. r. o.
+
+This file is part of ORIGAM (http://www.origam.org).
+
+ORIGAM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ORIGAM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export function isSaveShortcut(event: any) {
+  return event.key === "s" && (event.ctrlKey || event.metaKey);
+}
+
+export function isRefreshShortcut(event: any) {
+  return event.key === "r" && (event.ctrlKey || event.metaKey);
+}


### PR DESCRIPTION
Pressing the save shortcut did not result in sending the active field data to the server