### PR TITLE
FIX: Editor remains mounted when scrolling

### DIFF
--- a/frontend-html/src/model/actions-ui/DataView/TableView/onFieldKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onFieldKeyDown.ts
@@ -41,6 +41,7 @@ export function onFieldKeyDown(ctx: any) {
     try {
       const dataView = getDataView(ctx);
       const tablePanelView = getTablePanelView(ctx);
+      tablePanelView.handleEditorKeyDown(event);
       if( isSaveShortcut(event)){
         tablePanelView.setEditing(false);
         yield*flushCurrentRowData(ctx)();

--- a/frontend-html/src/model/entities/TablePanelView/TablePanelView.tsx
+++ b/frontend-html/src/model/entities/TablePanelView/TablePanelView.tsx
@@ -267,9 +267,24 @@ export class TablePanelView implements ITablePanelView {
     const _this = this;
     flow(function*() {
       if (_this.isEditing) {
+        if(!_this.isScrollByKeyboard) {
+          _this.setEditing(false);
+        }
         yield*flushCurrentRowData(_this)();
       }
     })();
+  }
+
+  hScrollDead: any;
+  isScrollByKeyboard = false;
+  @action.bound handleEditorKeyDown(event: any) {
+    if (event.key === "Tab" || event.key === "Enter") {
+      clearTimeout(this.hScrollDead);
+      this.isScrollByKeyboard = true;
+      this.hScrollDead = setTimeout(() => {
+        this.isScrollByKeyboard = false;
+      });
+    }
   }
 
   dontHandleNextScroll() {

--- a/frontend-html/src/model/entities/TablePanelView/types/ITablePanelView.ts
+++ b/frontend-html/src/model/entities/TablePanelView/types/ITablePanelView.ts
@@ -115,6 +115,8 @@ export interface ITablePanelView extends ITablePanelViewData {
 
   setCellRectangle(rowId: number, columnId: number, rectangle: ICellRectangle): void;
 
+  handleEditorKeyDown(event: any): void;
+
   clearCurrentCellEditData(): void;
 
   parent?: any;


### PR DESCRIPTION
Unmounting an editor during scroll was accidentally disabled when fixing another problem.