### PR TITLE
FIX: Busy indicator was not active right after row states were requested 2022.4

### DIFF
--- a/frontend-html/src/gui/connections/CScreenHeader.tsx
+++ b/frontend-html/src/gui/connections/CScreenHeader.tsx
@@ -36,6 +36,7 @@ import { T } from "utils/translation";
 import { ErrorBoundaryEncapsulated } from "gui/Components/Utilities/ErrorBoundary";
 import { IOpenedScreen } from "model/entities/types/IOpenedScreen";
 import { getActiveScreen } from "model/selectors/getActiveScreen";
+import {getRowStates} from "../../model/selectors/RowState/getRowStates";
 
 @observer
 export class CScreenHeader extends React.Component {
@@ -60,6 +61,15 @@ export class CScreenHeader extends React.Component {
 
 @observer
 class CScreenHeaderInner extends React.Component<{ activeScreen: IOpenedScreen }> {
+
+  areRowStatesLoading(){
+    const dataViews = this.props.activeScreen.content.formScreen?.dataViews;
+    if(!dataViews){
+      return false;
+    }
+    return dataViews.some(dataView => getRowStates(dataView).isWorking)
+  }
+
   render() {
     const {activeScreen} = this.props;
     const {content} = activeScreen;
@@ -71,7 +81,10 @@ class CScreenHeaderInner extends React.Component<{ activeScreen: IOpenedScreen }
       <>
         <h1 className={"printOnly"}>{activeScreen.formTitle}</h1>
         <ScreenHeader
-          isLoading={content.isLoading || getIsScreenOrAnyDataViewWorking(content.formScreen!)}
+          isLoading={
+            content.isLoading ||
+            getIsScreenOrAnyDataViewWorking(content.formScreen!) ||
+            this.areRowStatesLoading()}
         >
           <h1>{activeScreen.formTitle}</h1>
           {(isCancelButton || isNextButton) && <ScreenheaderDivider/>}

--- a/frontend-html/src/model/entities/DataView.ts
+++ b/frontend-html/src/model/entities/DataView.ts
@@ -421,7 +421,6 @@ export class DataView implements IDataView {
   @computed get isWorking() {
     return (
       this.lifecycle.isWorking ||
-      getRowStates(this).isWorking ||
       getLookupLoader(this).isWorking
     );
   }

--- a/frontend-html/src/model/entities/RowState.ts
+++ b/frontend-html/src/model/entities/RowState.ts
@@ -130,7 +130,7 @@ export class RowState implements IRowState {
   getValue(rowId: string) {
     if (!this.containers.has(rowId)) {
       this.containers.set(rowId, new RowStateContainer(rowId));
-      if (this.suppressWorkingStatus) {
+      if (!this.suppressWorkingStatus) {
         this.setWorkingStatus();
       }
     }

--- a/frontend-html/src/model/entities/RowState.ts
+++ b/frontend-html/src/model/entities/RowState.ts
@@ -28,6 +28,7 @@ import { FlowBusyMonitor } from "../../utils/flow";
 import { handleError } from "model/actions/handleError";
 
 const maxRowStatesInOneCall = 100;
+const loadingDelay = 666;
 
 export enum IIdState {
   LOADING = "LOADING",
@@ -44,8 +45,12 @@ export class RowState implements IRowState {
 
   monitor: FlowBusyMonitor = new FlowBusyMonitor();
 
+  @observable
+  _isWorking = false;
+  workingTimeout: NodeJS.Timeout | undefined;
+
   get isWorking() {
-    return this.monitor.isWorkingDelayed;
+    return this.monitor.isWorkingDelayed || this._isWorking;
   }
 
   @observable firstLoadingPerformed = false;
@@ -120,11 +125,14 @@ export class RowState implements IRowState {
     }.bind(this)
   );
 
-  triggerLoad = _.debounce(this.triggerLoadImm, 666);
+  triggerLoad = _.debounce(this.triggerLoadImm, loadingDelay);
 
   getValue(rowId: string) {
     if (!this.containers.has(rowId)) {
       this.containers.set(rowId, new RowStateContainer(rowId));
+      if (this.suppressWorkingStatus) {
+        this.setWorkingStatus();
+      }
     }
     let container = this.containers.get(rowId)!;
     if (!container.atom) {
@@ -145,6 +153,16 @@ export class RowState implements IRowState {
     } else {
       return this.containers.get(rowId)?.rowStateItem;
     }
+  }
+
+  private setWorkingStatus() {
+    clearTimeout(this.workingTimeout)
+    this.workingTimeout = setTimeout(() => {
+      this._isWorking = true;
+    });
+    this.workingTimeout = setTimeout(() => {
+      this._isWorking = false;
+    }, loadingDelay);
   }
 
   async loadValues(rowIds: string[]) {


### PR DESCRIPTION
so it was not clear that the displayed data was not in final state during scrolling