### PR TITLE
FIX: Upgrade @origam/utils to fix unsupported regex in older Safari (master)

### DIFF
--- a/frontend-html/package.json
+++ b/frontend-html/package.json
@@ -22,7 +22,7 @@
     "@origam/plugin-filter": "^2.0.2",
     "@origam/plugins": "^1.1.0",
     "@origam/styles": "^2.0.3",
-    "@origam/utils": "^1.3.4",
+    "@origam/utils": "^1.3.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/frontend-html/yarn.lock
+++ b/frontend-html/yarn.lock
@@ -1773,9 +1773,9 @@
     moment "^2.29.4"
 
 "@origam/utils@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@origam/utils/-/utils-1.3.4.tgz#fd09e01449401bd34aad37f1ee7e6780640aabe0"
-  integrity sha512-xjvYgMKD9iRhBvZ/mtT7eloLi4jOjO2Cml42VguNYrJBMmHyaZ7YR5p/60UaBUPEhl0UXgdiFLBAb/LYaiOLkQ==
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@origam/utils/-/utils-1.3.5.tgz#f9e2fc5dec941a247be1a3f84c87756e90a05c52"
+  integrity sha512-p41FbnRop9R0T/pChGI06yYDmHqMiCXpDWsWIrOVeWnm68nVKerO5j4pQJqNxh2AT1QXVcwIEges49cZBMgagg==
   dependencies:
     moment "^2.29.4"
 

--- a/frontend-html/yarn.lock
+++ b/frontend-html/yarn.lock
@@ -1772,7 +1772,7 @@
   dependencies:
     moment "^2.29.4"
 
-"@origam/utils@^1.3.4":
+"@origam/utils@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@origam/utils/-/utils-1.3.5.tgz#f9e2fc5dec941a247be1a3f84c87756e90a05c52"
   integrity sha512-p41FbnRop9R0T/pChGI06yYDmHqMiCXpDWsWIrOVeWnm68nVKerO5j4pQJqNxh2AT1QXVcwIEges49cZBMgagg==


### PR DESCRIPTION
Safari browser does not support lookbehind operator until version 16.4.