### PR TITLE
FIX: GetData was not called in a complex form 2022.4

### DIFF
--- a/frontend-html/src/model/entities/DataViewLifecycle/DataViewLifecycle.ts
+++ b/frontend-html/src/model/entities/DataViewLifecycle/DataViewLifecycle.ts
@@ -55,7 +55,7 @@ export class DataViewLifecycle implements IDataViewLifecycle {
   @action.bound
   start(): void {
     if (isLazyLoading(this)) {
-      this.startSelectedRowReaction();
+      this.startSelectedRowReaction(true);
     }
   }
 
@@ -227,9 +227,10 @@ export class DataViewLifecycle implements IDataViewLifecycle {
       } else {
         const parentRowId = getParentRowId(this);
         const masterRowId = getMasterRowId(this);
+        let entity = getEntity(this);
         data = !parentRowId || !masterRowId
           ? []
-          : yield getFormScreen(this).getData(getEntity(this), dataView.modelInstanceId, parentRowId, masterRowId);
+          : yield getFormScreen(this).getData(entity, dataView.modelInstanceId, parentRowId, masterRowId);
       }
       yield dataView.setRecords(data);
       dataView.selectFirstRow();


### PR DESCRIPTION
some of the reactions were not fired after opening the form leading to missing data. The reactions were fired after pressing screen refresh.