### PR TITLE
FEATURE: Optimize datastructure rule evaluation

### DIFF
--- a/backend/Origam.Rule/RowSecurityStateBuilder.cs
+++ b/backend/Origam.Rule/RowSecurityStateBuilder.cs
@@ -41,6 +41,7 @@ namespace Origam.Rule
         private XmlContainer originalData;
         private XmlContainer actualData;
         private bool isBuildable;
+        private RuleEvaluationCache ruleEvaluationCache;
 
 
         public static RowSecurityState BuildFull(RuleEngine ruleEngine,
@@ -104,6 +105,7 @@ namespace Origam.Rule
             actualData = DatasetTools.GetRowXml(row,
                     row.HasVersion(DataRowVersion.Proposed)
                     ? DataRowVersion.Proposed : DataRowVersion.Default);
+            ruleEvaluationCache = new RuleEvaluationCache();
             isBuildable = true;
         }
 
@@ -123,10 +125,10 @@ namespace Origam.Rule
                 ForegroundColor = formatting.ForeColor.ToArgb(),
                 AllowDelete = ruleEngine.EvaluateRowLevelSecurityState(
                     originalData, actualData, null, CredentialType.Delete,
-                    entityId, Guid.Empty, isNew),
+                    entityId, Guid.Empty, isNew, ruleEvaluationCache),
                 AllowCreate = ruleEngine.EvaluateRowLevelSecurityState(
                     originalData, actualData, null, CredentialType.Create,
-                    entityId, Guid.Empty, isNew)
+                    entityId, Guid.Empty, isNew, ruleEvaluationCache)
             };            
             return this;
         }
@@ -147,12 +149,12 @@ namespace Origam.Rule
                         EvaluateRowLevelSecurityState(originalData,
                             actualData, col.ColumnName,
                             CredentialType.Update,
-                            entityId, fieldId, isNew);
+                            entityId, fieldId, isNew, ruleEvaluationCache);
                     bool allowRead = ruleEngine.
                         EvaluateRowLevelSecurityState(originalData,
                             actualData, col.ColumnName,
                             CredentialType.Read,
-                            entityId, fieldId, isNew);
+                            entityId, fieldId, isNew, ruleEvaluationCache);
                     EntityFormatting fieldFormatting = ruleEngine.
                         Formatting(actualData, entityId, fieldId, null);
                     string dynamicLabel = ruleEngine.DynamicLabel(
@@ -220,7 +222,8 @@ namespace Origam.Rule
                         CredentialType.Create,
                         childEntityId, Guid.Empty,
                         row.RowState == DataRowState.Added 
-                            || row.RowState == DataRowState.Detached
+                            || row.RowState == DataRowState.Detached,
+                        ruleEvaluationCache
                     );
                     Result.Relations.Add(new RelationSecurityState(
                         rel.ChildTable.TableName, allowRelationCreate));

--- a/backend/Origam.Rule/RowSecurityStateBuilder.cs
+++ b/backend/Origam.Rule/RowSecurityStateBuilder.cs
@@ -1,6 +1,6 @@
 ﻿#region license
 /*
-Copyright 2005 - 2021 Advantage Solutions, s. r. o.
+Copyright 2005 - 2023 Advantage Solutions, s. r. o.
 
 This file is part of ORIGAM (http://www.origam.org).
 

--- a/backend/Origam.Rule/RuleEngine.cs
+++ b/backend/Origam.Rule/RuleEngine.cs
@@ -1755,23 +1755,43 @@ namespace Origam.Rule
 				        dataToUseForRule, action.Rule, action.Roles, null);
 		}
 
-		public bool EvaluateRowLevelSecurityState(XmlContainer originalData, XmlContainer actualData, string field, CredentialType type, Guid entityId, Guid fieldId, bool isNewRow)
+		public bool EvaluateRowLevelSecurityState(XmlContainer originalData,
+			XmlContainer actualData, string field, CredentialType type,
+			Guid entityId, Guid fieldId, bool isNewRow,
+			RuleEvaluationCache ruleEvaluationCache = null)
 		{
 			ArrayList rules = new ArrayList();
 				
 			IDataEntity entity = _persistence.SchemaProvider.RetrieveInstance(typeof(AbstractSchemaItem), new ModelElementKey(entityId)) as IDataEntity;
 
 			// field-level rules
-			if(field != null)
+			IDataEntityColumn column = null;
+			if (field != null)
 			{
 				// we retrieve the column from the child-items list
-				// this is very cost efficient, because when retrieving abstract columns (i.e. Id, RecordCreated, RecordUpdated), they are never cached
-				IDataEntityColumn column = entity.GetChildById(fieldId) as IDataEntityColumn;
+				// this is very cost efficient, because when retrieving
+				// abstract columns (i.e. Id, RecordCreated, RecordUpdated), they are never cached
+				column = entity.GetChildById(fieldId) as IDataEntityColumn;
 
-				// field not found, this would be e.g. a looked up column, which does not point to a real entity field id
+				// field not found, this would be e.g. a looked up column,
+				// which does not point to a real entity field id
 				if(column != null)
 				{
-					rules.AddRange(column.RowLevelSecurityRules);
+					if (column.RowLevelSecurityRules.Count == 0)
+					{
+						// shortcircuit processing of row level security rules
+						// for a column without it's own rules 
+						Boolean? result = ruleEvaluationCache?.GetRulelessFieldResult(
+							entityId, type);
+						if (result != null)
+						{
+							return result.Value;
+						}
+					}
+					else
+					{
+						rules.AddRange(column.RowLevelSecurityRules);
+					}
 				}
 			}
 
@@ -1781,9 +1801,12 @@ namespace Origam.Rule
 			{
 				rules.AddRange(entityRules);
 			}
-				
+
 			// no rules - permit
-			if(rules.Count == 0) return true;
+			if (rules.Count == 0)
+			{
+				return true;
+			}
 
 			rules.Sort();
 
@@ -1796,7 +1819,8 @@ namespace Origam.Rule
 					if(entityRule.DeleteCredential && type == CredentialType.Delete && isNewRow)
 					{
 						// always allow to delete new (not saved) records
-						return true;
+						return PutToRulelessCache(type, entityId,
+							ruleEvaluationCache, column, true);
 					}
 					else if(
 						(entityRule.UpdateCredential && type == CredentialType.Update)
@@ -1805,9 +1829,19 @@ namespace Origam.Rule
 						|| (entityRule.DeleteCredential && type == CredentialType.Delete)
 						)
 					{
-						if(IsRowLevelSecurityRuleMatching(entityRule, entityRule.ValueType == CredentialValueType.ActualValue ? actualData : originalData))
+						Boolean? result = ruleEvaluationCache?.Get(entityRule, entityId);
+						if (result == null)
 						{
-							return entityRule.Type == PermissionType.Permit;
+							result = IsRowLevelSecurityRuleMatching(entityRule,
+								entityRule.ValueType == CredentialValueType.ActualValue ?
+									actualData : originalData);
+							ruleEvaluationCache?.Put(entityRule, entityId, result.Value);
+						}
+						if (result.Value)
+						{
+							return PutToRulelessCache(type, entityId,
+								ruleEvaluationCache, column,
+								entityRule.Type == PermissionType.Permit);                            
 						}
 					}
 				}
@@ -1821,9 +1855,19 @@ namespace Origam.Rule
 						| (fieldRule.ReadCredential & type == CredentialType.Read)
 						)
 					{
-						if(IsRowLevelSecurityRuleMatching(fieldRule, fieldRule.ValueType == CredentialValueType.ActualValue ? actualData : originalData))
+						Boolean? result = ruleEvaluationCache?.Get(fieldRule, entityId);
+						if (result == null)
 						{
-							return fieldRule.Type == PermissionType.Permit;
+							result = IsRowLevelSecurityRuleMatching(fieldRule,
+								fieldRule.ValueType == CredentialValueType.ActualValue
+									? actualData : originalData);
+							ruleEvaluationCache?.Put(fieldRule, entityId, result.Value);
+						}
+						if (result.Value)
+						{
+							return PutToRulelessCache(type, entityId,
+								ruleEvaluationCache, column, 
+								fieldRule.Type == PermissionType.Permit);
 						}
 					}
 				}
@@ -1832,14 +1876,26 @@ namespace Origam.Rule
 			// no match
 			if(type == CredentialType.Read)
 			{
-				// permit for read
-				return true;
+				return PutToRulelessCache(type, entityId,
+					ruleEvaluationCache, column, true);
 			}
 			else
 			{
-				// deny for all the others
-				return false;
+				return PutToRulelessCache(type, entityId,
+					ruleEvaluationCache, column, false);
 			}
+		}
+
+		private static bool PutToRulelessCache(CredentialType type, Guid entityId,
+			RuleEvaluationCache ruleEvaluationCache, IDataEntityColumn column, bool value)
+		{
+			if (column?.RowLevelSecurityRules.Count == 0
+				&& ruleEvaluationCache != null)
+			{
+				ruleEvaluationCache.PutRulelessFieldResult(entityId, type,
+					value);
+			}
+			return value;
 		}
 
 		private bool IsRowLevelSecurityRuleMatching(AbstractEntitySecurityRule rule, XmlContainer data)

--- a/backend/Origam.Rule/RuleEvaluationCache.cs
+++ b/backend/Origam.Rule/RuleEvaluationCache.cs
@@ -1,29 +1,41 @@
-﻿using Origam.Extensions;
+﻿#region license
+/*
+Copyright 2005 - 2023 Advantage Solutions, s. r. o.
+
+This file is part of ORIGAM (http://www.origam.org).
+
+ORIGAM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ORIGAM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+#endregion
+
 using Origam.Schema.EntityModel;
 using System;
 using System.Collections.Generic;
-using System.Data;
 
 namespace Origam.Rule
 {
     public class RuleEvaluationCache
     {
-        Dictionary<Tuple<Guid, CredentialValueType, Guid>, bool> ruleCacheDict;
-        Dictionary<Tuple<Guid, CredentialType>, bool>
-            rulelessFieldSecurityRuleResultDict;
+        private readonly Dictionary<Tuple<Guid, CredentialValueType, Guid>, bool> 
+            rules = new();
+        private readonly Dictionary<Tuple<Guid, CredentialType>, bool>
+            rulelessFieldSecurityRuleResults = new();
 
-
-        public RuleEvaluationCache() {
-            ruleCacheDict =
-                new Dictionary<Tuple<Guid, CredentialValueType, Guid>, bool>();
-            rulelessFieldSecurityRuleResultDict =
-                new Dictionary<Tuple<Guid, CredentialType>, bool>();
-        }
-        public Boolean? Get(AbstractEntitySecurityRule rule, Guid entityId)
+        public bool? Get(AbstractEntitySecurityRule rule, Guid entityId)
         {
-            bool result;
-            if (ruleCacheDict.TryGetValue(new Tuple<Guid, CredentialValueType,
-                Guid>(rule.Id, rule.ValueType, entityId), out result))
+            if (rules.TryGetValue(new Tuple<Guid, CredentialValueType,
+                    Guid>(rule.Id, rule.ValueType, entityId), out var result))
             {
                 return result;
             }
@@ -32,16 +44,15 @@ namespace Origam.Rule
         public void Put(AbstractEntitySecurityRule rule, Guid entityId,
             bool value)
         {
-            ruleCacheDict.Add(new Tuple<Guid, CredentialValueType, Guid>
+            rules.Add(new Tuple<Guid, CredentialValueType, Guid>
                 (rule.Id, rule.ValueType, entityId), value);
         }
 
-        public Boolean? GetRulelessFieldResult(Guid entityId,
-            CredentialType type)
+        public bool? GetRulelessFieldResult(Guid entityId, CredentialType type)
         {
-            bool result;
-            if (rulelessFieldSecurityRuleResultDict.TryGetValue(
-                new Tuple<Guid, CredentialType>(entityId, type), out result))
+            if (rulelessFieldSecurityRuleResults.TryGetValue(
+                    new Tuple<Guid, CredentialType>(entityId, type), 
+                    out var result))
             {
                 return result;
             }
@@ -51,7 +62,7 @@ namespace Origam.Rule
         public void PutRulelessFieldResult(Guid entityId, CredentialType type,
             bool value)
         {
-            rulelessFieldSecurityRuleResultDict.Add(
+            rulelessFieldSecurityRuleResults.Add(
                 new Tuple<Guid, CredentialType>(entityId, type), value);
         }
     }

--- a/backend/Origam.Rule/RuleEvaluationCache.cs
+++ b/backend/Origam.Rule/RuleEvaluationCache.cs
@@ -1,0 +1,58 @@
+﻿using Origam.Extensions;
+using Origam.Schema.EntityModel;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Origam.Rule
+{
+    public class RuleEvaluationCache
+    {
+        Dictionary<Tuple<Guid, CredentialValueType, Guid>, bool> ruleCacheDict;
+        Dictionary<Tuple<Guid, CredentialType>, bool>
+            rulelessFieldSecurityRuleResultDict;
+
+
+        public RuleEvaluationCache() {
+            ruleCacheDict =
+                new Dictionary<Tuple<Guid, CredentialValueType, Guid>, bool>();
+            rulelessFieldSecurityRuleResultDict =
+                new Dictionary<Tuple<Guid, CredentialType>, bool>();
+        }
+        public Boolean? Get(AbstractEntitySecurityRule rule, Guid entityId)
+        {
+            bool result;
+            if (ruleCacheDict.TryGetValue(new Tuple<Guid, CredentialValueType,
+                Guid>(rule.Id, rule.ValueType, entityId), out result))
+            {
+                return result;
+            }
+            return null;
+        }
+        public void Put(AbstractEntitySecurityRule rule, Guid entityId,
+            bool value)
+        {
+            ruleCacheDict.Add(new Tuple<Guid, CredentialValueType, Guid>
+                (rule.Id, rule.ValueType, entityId), value);
+        }
+
+        public Boolean? GetRulelessFieldResult(Guid entityId,
+            CredentialType type)
+        {
+            bool result;
+            if (rulelessFieldSecurityRuleResultDict.TryGetValue(
+                new Tuple<Guid, CredentialType>(entityId, type), out result))
+            {
+                return result;
+            }
+            return null;
+        }
+
+        public void PutRulelessFieldResult(Guid entityId, CredentialType type,
+            bool value)
+        {
+            rulelessFieldSecurityRuleResultDict.Add(
+                new Tuple<Guid, CredentialType>(entityId, type), value);
+        }
+    }
+}

--- a/backend/Origam.Server/Controller/SessionController.cs
+++ b/backend/Origam.Server/Controller/SessionController.cs
@@ -173,7 +173,7 @@ namespace Origam.Server.Controllers
             return RunWithErrorHandler(() =>
             {
                 SessionStore ss = sessionObjects.SessionManager.GetSession(updateData.SessionFormIdentifier);
-                IEnumerable<ChangeInfo> output = ss.UpdateObjectAndGetChanges(
+                IEnumerable<ChangeInfo> output = ss.UpdateObject(
                     entity: updateData.Entity,
                     id: updateData.Id,
                     property: updateData.Property,

--- a/backend/Origam.Server/Controller/SessionController.cs
+++ b/backend/Origam.Server/Controller/SessionController.cs
@@ -173,7 +173,7 @@ namespace Origam.Server.Controllers
             return RunWithErrorHandler(() =>
             {
                 SessionStore ss = sessionObjects.SessionManager.GetSession(updateData.SessionFormIdentifier);
-                IEnumerable<ChangeInfo> output = ss.UpdateObject(
+                IEnumerable<ChangeInfo> output = ss.UpdateObjectAndGetChanges(
                     entity: updateData.Entity,
                     id: updateData.Id,
                     property: updateData.Property,

--- a/backend/Origam.Server/Session Stores/SaveableSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SaveableSessionStore.cs
@@ -233,10 +233,17 @@ namespace Origam.Server
             }
         }
 
+        public override IEnumerable<ChangeInfo> UpdateObject(
+            string entity, object id, string property, object newValue)
+        {
+            return UpdateObjectWithDependenies(entity, id,
+				property, newValue, true);
+        }
+
         public IEnumerable<ChangeInfo>
             UpdateObjectWithDependenies(
             string entity, object id, string property, object newValue,
-            bool isTopLevel = true)
+            bool isTopLevel)
         {
             InitializeFieldDependencies();
             DataTable table = GetTable(entity, this.Data);
@@ -269,12 +276,12 @@ namespace Origam.Server
             // (last) update
             if (isTopLevel)
             {
-                return base.UpdateObjectAndGetChanges(entity, id,
+                return base.UpdateObject(entity, id,
                     property, newValue);
             }
             else 
             {
-                base.UpdateObject(entity, id, property, newValue);
+                base.UpdateObjectsWithoutGetChanges(entity, id, property, newValue);
                 return new List<ChangeInfo>();
             }
         }

--- a/backend/Origam.Server/Session Stores/SessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SessionStore.cs
@@ -41,7 +41,6 @@ using MoreLinq;
 using Newtonsoft.Json.Linq;
 using Origam.Extensions;
 using Origam.Service.Core;
-using Microsoft.AspNetCore.Routing.Constraints;
 
 namespace Origam.Server
 {

--- a/backend/Origam.Server/Session Stores/SessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SessionStore.cs
@@ -1598,7 +1598,7 @@ namespace Origam.Server
             }
         }
 
-        public virtual IEnumerable<ChangeInfo> UpdateObjectAndGetChanges(
+        public virtual IEnumerable<ChangeInfo> UpdateObject(
             string entity, object id, string property, object newValue)
         {
             lock (_lock)
@@ -1608,7 +1608,7 @@ namespace Origam.Server
             }
         }
 
-        public virtual void UpdateObject(
+        public void UpdateObjectsWithoutGetChanges(
             string entity, object id, string property, object newValue)
         {
             lock (_lock)
@@ -2199,7 +2199,7 @@ namespace Origam.Server
             {
                 foreach (DictionaryEntry entry in values)
                 {
-                    result.AddRange(UpdateObjectAndGetChanges(entity, entry.Key, property, entry.Value));
+                    result.AddRange(UpdateObject(entity, entry.Key, property, entry.Value));
                 }
             }
 
@@ -2214,7 +2214,7 @@ namespace Origam.Server
             {
                 foreach (DictionaryEntry entry in values)
                 {
-                    result.AddRange(UpdateObjectAndGetChanges(entity, id, (string)entry.Key, entry.Value));
+                    result.AddRange(UpdateObject(entity, id, (string)entry.Key, entry.Value));
                 }
             }
 
@@ -2230,7 +2230,7 @@ namespace Origam.Server
                 {
                     foreach (KeyValuePair<string, object> entry in updateData.Values)
                     {
-                        result.AddRange(UpdateObjectAndGetChanges(entity, updateData.RowId, (string)entry.Key, entry.Value));
+                        result.AddRange(UpdateObject(entity, updateData.RowId, (string)entry.Key, entry.Value));
                     }
                 }
             }


### PR DESCRIPTION
* call rowstates in the final UpdateObject() method, not from UpdateObject() coming from doing dependency field reseting
* compute and remember a row-level-security result for a security type (read, write, etc) and column which doesn’t have any rule and apply it for all the further columns without any field-level-row-level security rule
* compute and cache a row-level-security rule result for a current row and use cached value whenever it’s needed again
