### PR TITLE
FEATURE: Optimize datastructure rule evaluation

### DIFF
--- a/backend/Origam.Rule/RowSecurityStateBuilder.cs
+++ b/backend/Origam.Rule/RowSecurityStateBuilder.cs
@@ -1,6 +1,6 @@
 ﻿#region license
 /*
-Copyright 2005 - 2021 Advantage Solutions, s. r. o.
+Copyright 2005 - 2023 Advantage Solutions, s. r. o.
 
 This file is part of ORIGAM (http://www.origam.org).
 
@@ -41,6 +41,7 @@ namespace Origam.Rule
         private XmlContainer originalData;
         private XmlContainer actualData;
         private bool isBuildable;
+        private RuleEvaluationCache ruleEvaluationCache;
 
 
         public static RowSecurityState BuildFull(RuleEngine ruleEngine,
@@ -104,6 +105,7 @@ namespace Origam.Rule
             actualData = DatasetTools.GetRowXml(row,
                     row.HasVersion(DataRowVersion.Proposed)
                     ? DataRowVersion.Proposed : DataRowVersion.Default);
+            ruleEvaluationCache = new RuleEvaluationCache();
             isBuildable = true;
         }
 
@@ -123,10 +125,10 @@ namespace Origam.Rule
                 ForegroundColor = formatting.ForeColor.ToArgb(),
                 AllowDelete = ruleEngine.EvaluateRowLevelSecurityState(
                     originalData, actualData, null, CredentialType.Delete,
-                    entityId, Guid.Empty, isNew),
+                    entityId, Guid.Empty, isNew, ruleEvaluationCache),
                 AllowCreate = ruleEngine.EvaluateRowLevelSecurityState(
                     originalData, actualData, null, CredentialType.Create,
-                    entityId, Guid.Empty, isNew)
+                    entityId, Guid.Empty, isNew, ruleEvaluationCache)
             };            
             return this;
         }
@@ -147,12 +149,12 @@ namespace Origam.Rule
                         EvaluateRowLevelSecurityState(originalData,
                             actualData, col.ColumnName,
                             CredentialType.Update,
-                            entityId, fieldId, isNew);
+                            entityId, fieldId, isNew, ruleEvaluationCache);
                     bool allowRead = ruleEngine.
                         EvaluateRowLevelSecurityState(originalData,
                             actualData, col.ColumnName,
                             CredentialType.Read,
-                            entityId, fieldId, isNew);
+                            entityId, fieldId, isNew, ruleEvaluationCache);
                     EntityFormatting fieldFormatting = ruleEngine.
                         Formatting(actualData, entityId, fieldId, null);
                     string dynamicLabel = ruleEngine.DynamicLabel(
@@ -220,7 +222,8 @@ namespace Origam.Rule
                         CredentialType.Create,
                         childEntityId, Guid.Empty,
                         row.RowState == DataRowState.Added 
-                            || row.RowState == DataRowState.Detached
+                            || row.RowState == DataRowState.Detached,
+                        ruleEvaluationCache
                     );
                     Result.Relations.Add(new RelationSecurityState(
                         rel.ChildTable.TableName, allowRelationCreate));

--- a/backend/Origam.Rule/RuleEvaluationCache.cs
+++ b/backend/Origam.Rule/RuleEvaluationCache.cs
@@ -1,0 +1,69 @@
+﻿#region license
+/*
+Copyright 2005 - 2023 Advantage Solutions, s. r. o.
+
+This file is part of ORIGAM (http://www.origam.org).
+
+ORIGAM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ORIGAM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+#endregion
+
+using Origam.Schema.EntityModel;
+using System;
+using System.Collections.Generic;
+
+namespace Origam.Rule
+{
+    public class RuleEvaluationCache
+    {
+        private readonly Dictionary<Tuple<Guid, CredentialValueType, Guid>, bool> 
+            rules = new();
+        private readonly Dictionary<Tuple<Guid, CredentialType>, bool>
+            rulelessFieldSecurityRuleResults = new();
+
+        public bool? Get(AbstractEntitySecurityRule rule, Guid entityId)
+        {
+            if (rules.TryGetValue(new Tuple<Guid, CredentialValueType,
+                    Guid>(rule.Id, rule.ValueType, entityId), out var result))
+            {
+                return result;
+            }
+            return null;
+        }
+        public void Put(AbstractEntitySecurityRule rule, Guid entityId,
+            bool value)
+        {
+            rules.Add(new Tuple<Guid, CredentialValueType, Guid>
+                (rule.Id, rule.ValueType, entityId), value);
+        }
+
+        public bool? GetRulelessFieldResult(Guid entityId, CredentialType type)
+        {
+            if (rulelessFieldSecurityRuleResults.TryGetValue(
+                    new Tuple<Guid, CredentialType>(entityId, type), 
+                    out var result))
+            {
+                return result;
+            }
+            return null;
+        }
+
+        public void PutRulelessFieldResult(Guid entityId, CredentialType type,
+            bool value)
+        {
+            rulelessFieldSecurityRuleResults.Add(
+                new Tuple<Guid, CredentialType>(entityId, type), value);
+        }
+    }
+}


### PR DESCRIPTION
* call rowstates in the final UpdateObject() method, not from UpdateObject() coming from doing dependency field reseting
* compute and remember a row-level-security result for a security type (read, write, etc) and column which doesn’t have any rule and apply it for all the further columns without any field-level-row-level security rule
* compute and cache a row-level-security rule result for a current row and use cached value whenever it’s needed again

---------