### PR TITLE
FIX: Adding/deleting a row took a long time when the filters were open

### DIFF
--- a/frontend-html/src/model/entities/FilterConfiguration.ts
+++ b/frontend-html/src/model/entities/FilterConfiguration.ts
@@ -39,6 +39,11 @@ export class FilterConfiguration implements IFilterConfiguration {
   implicitFilters: IImplicitFilter[];
   @observable activeFilters: IFilter[] = [];
 
+  @computed
+  get activeCompleteFilters(){
+    return this.activeFilters.filter(x=> x.setting.isComplete);
+  }
+
   registerFilteringOnOffHandler(handler: (filteringOn: boolean) => void) {
     this.filteringOnOffHandlers.push(handler);
   }
@@ -107,7 +112,7 @@ export class FilterConfiguration implements IFilterConfiguration {
           return false;
         }
       }
-      for (let term of this.activeFilters) {
+      for (let term of this.activeCompleteFilters) {
         if ((!ignorePropertyId || ignorePropertyId !== term.propertyId) &&
           !this.userFilterPredicate(row, term)) {
           return false;

--- a/frontend-html/src/model/entities/ListRowContainer.ts
+++ b/frontend-html/src/model/entities/ListRowContainer.ts
@@ -90,7 +90,7 @@ export class ListRowContainer implements IRowsContainer {
       .map(ordering => this.getOrderingProperty(dataView, ordering))
       .filter((prop) => prop.column === "ComboBox");
 
-    const filterComboProps = this.filterConfiguration.activeFilters
+    const filterComboProps = this.filterConfiguration.activeCompleteFilters
       .map((term) => getDataViewPropertyById(this.filterConfiguration, term.propertyId)!)
       .filter((prop) => prop.column === "ComboBox");
     const allComboProps = Array.from(new Set(filterComboProps.concat(orderingComboProps)));

--- a/frontend-html/src/model/entities/types/IFilterConfiguration.ts
+++ b/frontend-html/src/model/entities/types/IFilterConfiguration.ts
@@ -29,6 +29,7 @@ export interface IFilterConfiguration extends IFilterConfigurationData {
 
   isFilterControlsDisplayed: boolean;
   activeFilters: IFilter[];
+  activeCompleteFilters: IFilter[];
 
   filteringFunction(ignorePropertyId?: string): (row: any[], forceRowId?: string) => boolean;
 


### PR DESCRIPTION
no values were filled in the filters. Happened on an eagerly loaded screen with 10000 rows. The operations took about 10 sec.