### PR TITLE
FIX: Escape did not delete the just inserted row

### DIFF
--- a/frontend-html/src/model/entities/ListRowContainer.ts
+++ b/frontend-html/src/model/entities/ListRowContainer.ts
@@ -197,7 +197,7 @@ export class ListRowContainer implements IRowsContainer {
     if (shouldLockNewRowPosition) {
       this.forcedLastRowId = this.rowIdGetter(row);
     }
-    await this.updateSortAndFilter();
+    await this.updateSortAndFilter({retainPreviousSelection: true});
   }
 
   async set(rowsIn: any[][], rowOffset: number): Promise<any> {


### PR DESCRIPTION
if there was more than one row in the grid already