### PR TITLE
FIX: Loading reports in iframe fails

### DIFF
--- a/frontend-html/src/gui/connections/CScreen.tsx
+++ b/frontend-html/src/gui/connections/CScreen.tsx
@@ -30,6 +30,7 @@ import { ErrorBoundaryEncapsulated } from "gui/Components/Utilities/ErrorBoundar
 import { IFormScreenEnvelope } from "model/entities/types/IFormScreen";
 import { onIFrameClick } from "model/actions/WebScreen/onIFrameClick";
 import { onScreenTabCloseClick } from "model/actions-ui/ScreenTabHandleRow/onScreenTabCloseClick";
+import { getApi } from "model/selectors/getApi";
 
 const WebScreenComposite: React.FC<{ openedScreen: IOpenedScreen }> = observer((props) => {
   const {openedScreen} = props;
@@ -47,11 +48,27 @@ const WebScreenComposite: React.FC<{ openedScreen: IOpenedScreen }> = observer((
     },
     [openedScreen]
   );
-
+  function loadInternalApiDataWithAuthentication() {
+    const fetchData = async () => {
+      if (!openedScreen.screenUrl) {
+        return;
+      }
+      if (1){
+        setSource(openedScreen.screenUrl);
+        return;
+      }
+      const api = getApi(props.openedScreen);
+      const url = openedScreen.screenUrl.replace("internalApi/", "")
+      const content = await api.callUserApi(url);
+      setSource(URL.createObjectURL(content));
+    }
+    fetchData().catch(error => console.error(error));
+  }
   useEffect(() => {
     if (openedScreen.screenUrl) {
       setLoading(true);
     }
+    loadInternalApiDataWithAuthentication();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => {
     const handle = setInterval(() => {

--- a/frontend-html/src/model/entities/OrigamAPI.ts
+++ b/frontend-html/src/model/entities/OrigamAPI.ts
@@ -872,6 +872,13 @@ export class OrigamAPI implements IApi {
     fileDownload(response.data, fileName);
   }
 
+  async callUserApi(screenUrl: string): Promise<Blob>{
+    return (await this.axiosInstance.get(
+      screenUrl,
+      { responseType: 'blob'}))
+      .data;
+  }
+
   async getMenuIdByReference(data: { Category: string; ReferenceId: any }): Promise<string> {
     return (await this.axiosInstance.post(`/DeepLink/GetMenuId`, data)).data;
   }

--- a/frontend-html/src/model/entities/types/IApi.ts
+++ b/frontend-html/src/model/entities/types/IApi.ts
@@ -441,6 +441,8 @@ export interface IApi {
     RowIds: any[];
     LazyLoadedEntityInput: ILazyLoadedEntityInput | undefined;
   }): Promise<any>;
+
+  callUserApi(screenUrl: string): Promise<Blob>;
 }
 
 export interface ILazyLoadedEntityInput {


### PR DESCRIPTION
 revert of: Indirect iframe content loading reverted (#2006) - and fixing it the way it worked