### PR TITLE
FIX: Left and right arrows in grid disabled

### DIFF
--- a/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
@@ -49,16 +49,6 @@ export function onTableKeyDown(ctx: any) {
           yield*selectNextRow(ctx)();
           getTablePanelView(ctx).scrollToCurrentCell();
           break;
-        case "ArrowLeft":
-          selectPrevColumn(ctx)();
-          event.preventDefault();
-          getTablePanelView(ctx).scrollToCurrentCell();
-          break;
-        case "ArrowRight":
-          selectNextColumn(ctx)();
-          event.preventDefault();
-          getTablePanelView(ctx).scrollToCurrentCell();
-          break;
         case "F2":
           getTablePanelView(ctx).setEditing(true);
           event.preventDefault();


### PR DESCRIPTION
 because the active column was not visible while no editor was open