### PR TITLE
FIX: Soap service endpoint doesn’t return a valid content length when…

### DIFF
--- a/backend/Origam.Server/Middleware/ReturnOldDotNetAssemblyReferencesInSoapMiddleware.cs
+++ b/backend/Origam.Server/Middleware/ReturnOldDotNetAssemblyReferencesInSoapMiddleware.cs
@@ -50,6 +50,7 @@ namespace Origam.Server.Middleware
                 await next(context);
                 using (var responseStream = await FixAssemblyReferencesInResponse(context.Response))
                 {
+                    context.Response.Headers.ContentLength = null;
                     await responseStream.CopyToAsync(originalBodyStream);
                 }
             }

--- a/backend/Origam.Server/Origam.Server.csproj
+++ b/backend/Origam.Server/Origam.Server.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
     <PackageReference Include="Origam.Service.Core" Version="2.1.1" />
-    <PackageReference Include="SoapCore" Version="1.1.0.38" />
+    <PackageReference Include="SoapCore" Version="1.1.0.39" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.2" />
     <PackageReference Include="UAParser" Version="3.1.47" />


### PR DESCRIPTION
… ExpectAndReturnOldDotNetAssemblyReferences=true in application.json