### PR TITLE
FIX: Soap service endpoint doesn’t return a valid content length

### DIFF
--- a/backend/Origam.Server/Middleware/ReturnOldDotNetAssemblyReferencesInSoapMiddleware.cs
+++ b/backend/Origam.Server/Middleware/ReturnOldDotNetAssemblyReferencesInSoapMiddleware.cs
@@ -50,6 +50,7 @@ namespace Origam.Server.Middleware
                 await next(context);
                 using (var responseStream = await FixAssemblyReferencesInResponse(context.Response))
                 {
+                    context.Response.Headers.ContentLength = null;
                     await responseStream.CopyToAsync(originalBodyStream);
                 }
             }


### PR DESCRIPTION
When ExpectAndReturnOldDotNetAssemblyReferences=true in application.json 
Co-authored-by: Václav Urbánek <vaclav.urbanek@advantages.cz>