### PR TITLE
FIX: Rule engine fixes

### DIFF
--- a/backend/Origam.Rule/DatasetRuleHandler.cs
+++ b/backend/Origam.Rule/DatasetRuleHandler.cs
@@ -265,11 +265,7 @@ namespace Origam.Rule
 
 		private void table_RowChanged(object sender, DataRowChangeEventArgs e)
 		{
-			// The RowChanged event fires after every call to DataRow.EndEdit().
-			// Every field change calls the DataRow.EndEdit(). This led to 
-			// execution of the OnRowChanged handler after changing just a single
-			// field which added undesired overhead.
-			if (e.Action != DataRowAction.Change && e.Action != DataRowAction.Nothing)
+			if (e.Action != DataRowAction.Nothing && e.Action != DataRowAction.Commit)
 			{
 				OnRowChanged(e, _currentRuleDocument, _ruleSet, _ruleEngine);
 			}

--- a/backend/Origam.Server/Session Stores/SessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SessionStore.cs
@@ -1380,7 +1380,18 @@ namespace Origam.Server
             }
 
             // data not requested (data less session)
-            return RowStatesForDataLessSessions(entity, ids, profileId);
+            try
+            {
+                lock (_lock)    // no update should be done in the meantime when rules are not handled
+                {
+                    this.UnregisterEvents();
+                    return RowStatesForDataLessSessions(entity, ids, profileId);
+                }
+            }
+            finally
+            {
+                this.RegisterEvents();
+            }
         }
 
         private ArrayList RowStatesForDataLessSessions(string entity, object[] ids, object profileId)


### PR DESCRIPTION
* FIX: Querying row states was executing rule engine without a reason on lazy-loaded screens
* FIX: Reverted UpdateObject optimizations - rules were not recalculated on parent/child entities