### PR TITLE
FIX: Remove mvp and rule engine stabilization fixes (#2188)

### DIFF
--- a/backend/Origam.Rule/RuleEngine.cs
+++ b/backend/Origam.Rule/RuleEngine.cs
@@ -41,6 +41,7 @@ using Origam.Extensions;
 using Origam.Rule.Xslt;
 using Origam.Service.Core;
 using Origam.Workbench;
+using System.Data.Common;
 
 namespace Origam.Rule
 {
@@ -981,9 +982,13 @@ namespace Origam.Rule
 							}
 						}
 					}
-					catch
+					catch (Exception e)
 					{
 						row.CancelEdit();
+						if (log.IsErrorEnabled)
+						{
+							log.Error("Exception ocurred during evaluation of rule queue", e);
+						}
 						_ruleQueue.Clear();
 						throw;
 					}

--- a/backend/Origam.Rule/Xslt/CompiledXsltEngine.cs
+++ b/backend/Origam.Rule/Xslt/CompiledXsltEngine.cs
@@ -71,9 +71,13 @@ namespace Origam.Rule.Xslt
         public override void Transform(object engine, XsltArgumentList xslArg, XPathDocument sourceXpathDoc, IXmlContainer resultDoc)
         {
             XslCompiledTransform xslt = engine as XslCompiledTransform;
-            Mvp.Xml.Common.Xsl.XslReader xslReader = new Mvp.Xml.Common.Xsl.XslReader(xslt);
-            xslReader.StartTransform(new Mvp.Xml.Common.Xsl.XmlInput(sourceXpathDoc), xslArg);
-            resultDoc.Load(xslReader);
+            MemoryStream stream = new MemoryStream();
+            xslt.Transform(sourceXpathDoc, xslArg, stream);
+            stream.Position = 0;
+            using (XmlReader reader = XmlReader.Create(stream))
+            {
+                resultDoc.Load(reader);
+            }
         }
 
         public override void Transform(object engine, XsltArgumentList xslArg, XPathDocument sourceXpathDoc, XmlTextWriter xwr)

--- a/backend/Origam.Schema.EntityModel/Data Structure/DataStructureRule.cs
+++ b/backend/Origam.Schema.EntityModel/Data Structure/DataStructureRule.cs
@@ -60,6 +60,20 @@ namespace Origam.Schema.EntityModel
 		
 		public Guid DataStructureEntityId;
 
+		private string entityName;
+
+		public String EntityName
+		{
+			get
+			{
+				if (entityName == null)
+				{
+					entityName = Entity.Name;
+				}
+				return entityName;
+			}
+		}
+
 		[TypeConverter(typeof(DataQueryEntityConverter))]
 		[RefreshProperties(RefreshProperties.Repaint)]
         [XmlReference("entity", "DataStructureEntityId")]

--- a/backend/Origam.Schema.EntityModel/Data Structure/DataStructureRuleSet.cs
+++ b/backend/Origam.Schema.EntityModel/Data Structure/DataStructureRuleSet.cs
@@ -95,7 +95,7 @@ namespace Origam.Schema.EntityModel
 			var result = new ArrayList();
 			foreach(DataStructureRule rule in Rules())
 			{
-				if(rule.Entity.Name == entityName 
+				if(rule.EntityName == entityName 
 				&& rule.RuleDependencies.Count == 0)
 				{
 					result.Add(rule);

--- a/backend/Origam.Workflow/ProfilingTools.cs
+++ b/backend/Origam.Workflow/ProfilingTools.cs
@@ -177,6 +177,7 @@ namespace Origam.Workflow
 
         public Stopwatch Stop(int hash)
         {
+            if (!runningOperations.ContainsKey(hash)) return new Stopwatch();
             Stopwatch stopwatch = runningOperations[hash].Stopwatch;
             stopwatch.Stop();
             runningOperations.Remove(hash);


### PR DESCRIPTION
* FIX: Fetching entity name while processing rules caused some delays with rule/data intensive processes
* FIX: Server could hard crash sometimes when workflow measured execution failed
* DEV: It could happen to a rule queue to fail, an exception is logged now
* FIX: Remove Mvp XslCompiledTransform, it caused unstable behaviour at XmlNameTable (infinite loop)