### PR TITLE
FIX: Empty work queue entry when loader worflow returns empty ROOT element

### DIFF
--- a/backend/Origam.Workflow/WorkQueue/WorkQueueWorkflowLoader.cs
+++ b/backend/Origam.Workflow/WorkQueue/WorkQueueWorkflowLoader.cs
@@ -203,6 +203,12 @@ namespace Origam.Workflow.WorkQueue
 				{
 					xpath += "/" + secondChild.Name;
 				}
+				else
+				{
+					// one empty node from the loader workflow,
+					// e.g. <ROOT/> - nothing came
+					return false;
+				}
 			}
 			else
 			{


### PR DESCRIPTION
FIX: Work queue loader now returns 0 items when only one (empty) node e.g. <ROOT/> is returned from a loader workflow