### PR TITLE
FIX: UpdateObject was running after clicking on any row 2023.1

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.tsx
@@ -63,14 +63,10 @@ export class DateTimeEditor extends React.Component<{
   className?: string;
 }> {
   @observable isDroppedDown = false;
-
   @observable isShowFormatHintTooltip = false;
-
   refDropdowner = (elm: Dropdowner | null) => (this.elmDropdowner = elm);
   elmDropdowner: Dropdowner | null = null;
-
   editorState = new DesktopEditorState(this.props.value);
-
   editorModel = new DateEditorModel(
     this.editorState,
     this.props.outputFormat,
@@ -79,6 +75,7 @@ export class DateTimeEditor extends React.Component<{
     this.props.onKeyDown,
     this.props.onEditorBlur,
     this.props.onChangeByCalendar);
+  blurHandled = false;
 
   @action.bound handleDropperClick(event: any) {
     event.stopPropagation();
@@ -115,7 +112,7 @@ export class DateTimeEditor extends React.Component<{
         async ()=> {
           const event = {} as any;
           event.type = "click";
-          await this.handleInputBlur(event)();
+          await this.handleInputBlur(event);
         });
     }
   }
@@ -166,12 +163,16 @@ export class DateTimeEditor extends React.Component<{
   }
 
   @action.bound
-  handleInputBlur(event: any) {
+  async handleInputBlur(event: any) {
+    if(this.blurHandled){
+      return;
+    }
+    this.blurHandled = true;
     const self = this;
-    return flow(function*() {
+    await flow(function*() {
       self.setShowFormatHint(false);
       yield self.editorModel.handleInputBlur(event);
-    });
+    })();
   }
 
   @action.bound handleKeyDown(event: any) {
@@ -274,7 +275,7 @@ export class DateTimeEditor extends React.Component<{
                     }}
                     className={S.input +" "+ this.props.className + " " + (this.props.isReadOnly ? S.readOnlyInput : "")}
                     type="text"
-                    onBlur={event => this.handleInputBlur(event)()}
+                    onBlur={event => this.handleInputBlur(event)}
                     onFocus={this.handleFocus}
                     ref={(elm) => {
                       this.refInput(elm);
@@ -332,7 +333,7 @@ export class DateTimeEditor extends React.Component<{
           title={this.editorModel.autocompletedText + '\n' + this.props.outputFormat}
           className={S.input + " " + (this.props.isReadOnly ? S.readOnlyInput : "")}
           type="text"
-          onBlur={event => this.handleInputBlur(event)()}
+          onBlur={event => this.handleInputBlur(event)}
           onFocus={this.handleFocus}
           ref={this.refInput}
           value={this.editorModel.textFieldValue}

--- a/frontend-html/src/gui/Components/ScreenElements/Editors/NumberEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/NumberEditor.tsx
@@ -53,6 +53,7 @@ export class NumberEditor extends React.Component<{
   state = { value: this.formatForDisplay(this.props.value), cursorPosition: 0};
   disposer: undefined | (()=> void);
   inputRef = React.createRef<HTMLInputElement>();
+  blurHandled = false;
 
   formatForDisplay(value: string | number | null){
     if(value === null || value === ""){
@@ -124,6 +125,10 @@ export class NumberEditor extends React.Component<{
 
   @action.bound
   async handleBlur(event: any) {
+    if(this.blurHandled){
+      return;
+    }
+    this.blurHandled = true;
     await runInFlowWithHandler({
       ctx: this.props.property,
       action: async () => {

--- a/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableViewEditor.tsx
+++ b/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableViewEditor.tsx
@@ -152,10 +152,10 @@ export class TableViewEditor extends React.Component<{
             onEditorBlur={this.props.onEditorBlur}
             isRichText={false}
             isMultiline={this.props.property!.multiline}
-            subscribeToFocusManager={(editor) =>
+            subscribeToFocusManager={(editor, onBlur) =>
             {
               gridFocusManager.activeEditor = editor
-              gridFocusManager.editorBlur = this.props.onEditorBlur;
+              gridFocusManager.editorBlur = onBlur;
             }}
           />
         );


### PR DESCRIPTION
while there were no changes. Happened in an eagerly loaded screen after making changes to two fields in a row very fast (pressing tab) and then creating a new row with insert. HandleBlur was called twice. The second call set a dirty value again after it had been handled by an UpdateObject call. The dirty value was never cleared because of logic in clearRecordDirtyValues method in DataTable. The dirty value then caused an UpdateObject to be called after every click.