### PR TITLE
FIX: UpdateObject was running after clicking on any row

### DIFF
--- a/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableViewEditor.tsx
+++ b/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableViewEditor.tsx
@@ -65,12 +65,12 @@ import { makeOnAddNewRecordClick } from "gui/connections/NewRecordScreen";
         value: value,
       }),
     onEditorBlur: async (event: any) => {
-      await onFieldBlur(tablePanelView)();
       const gridFocusManager = getGridFocusManager(tablePanelView);
       if(!event?.target || gridFocusManager.activeEditor === event.target){
         gridFocusManager.activeEditor = undefined;
         gridFocusManager.editorBlur = undefined;
       }
+      await onFieldBlur(tablePanelView)();
     },
     onEditorKeyDown: (event: any) => {
       event.persist();


### PR DESCRIPTION
while there were no changes. Happened in an eagerly loaded screen after making changes to two fields in a row very fast (pressing tab) and then creating a new row with insert. HandleBlur was called twice. The second call set a dirty value again after it had been handled by an UpdateObject call. The dirty value was never cleared because of logic in clearRecordDirtyValues method in DataTable. The dirty value then caused an UpdateObject to be called after every click.