### PR TITLE
FIX: Possible to invoke ExecuteAction while UpdateObject was running

### DIFF
--- a/backend/Origam.Server/Model/UIService/WorkflowNextInput.cs
+++ b/backend/Origam.Server/Model/UIService/WorkflowNextInput.cs
@@ -27,6 +27,5 @@ namespace Origam.Server.Model.UIService
     public class WorkflowNextInput
     {
         public Guid SessionFormIdentifier { get; set; }
-        public List<string> CachedFormIds { get; set; }
-    }
+    } 
 }

--- a/backend/Origam.Server/ServerCoreUIService.cs
+++ b/backend/Origam.Server/ServerCoreUIService.cs
@@ -583,7 +583,7 @@ namespace Origam.Server
                 is WorkflowSessionStore workflowSessionStore)
             {
                 return (UIResult) workflowSessionStore.ExecuteAction(
-                    SessionStore.ACTION_NEXT, workflowNextInput.CachedFormIds);
+                    SessionStore.ACTION_NEXT);
             }
             return null;
         }

--- a/backend/Origam.Server/Session Stores/ParameterSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/ParameterSessionStore.cs
@@ -168,7 +168,7 @@ namespace Origam.Server
             this.DirtyEnabledEntities.Add("SD");
         }
 
-        public override object ExecuteAction(string actionId)
+        public override object ExecuteActionInternal(string actionId)
         {
             switch (actionId)
             {

--- a/backend/Origam.Server/Session Stores/SaveableSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SaveableSessionStore.cs
@@ -231,8 +231,11 @@ namespace Origam.Server
         public override IEnumerable<ChangeInfo> UpdateObject(
             string entity, object id, string property, object newValue)
         {
-            return UpdateObjectWithDependenies(entity, id,
-				property, newValue, true);
+            lock (_lock)
+            {
+                return UpdateObjectWithDependenies(entity, id,
+                    property, newValue, true);
+            }
         }
 
         public IEnumerable<ChangeInfo>

--- a/backend/Origam.Server/Session Stores/SelectionDialogSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SelectionDialogSessionStore.cs
@@ -96,32 +96,18 @@ namespace Origam.Server
             SetDataSource(data);
         }
 
-        public override object ExecuteAction(string actionId)
+        public override object ExecuteActionInternal(string actionId)
         {
-            if (this.IsProcessing)
+            switch (actionId)
             {
-                throw new Exception(Resources.ErrorCommandInProgress);
-            }
+                case ACTION_REFRESH:
+                    return Refresh();
 
-            this.IsProcessing = true;
+                case ACTION_NEXT:
+                    return Next();
 
-            try
-            {
-                switch (actionId)
-                {
-                    case ACTION_REFRESH:
-                        return Refresh();
-
-                    case ACTION_NEXT:
-                        return Next();
-
-                    default:
-                        throw new ArgumentOutOfRangeException("actionId", actionId, Resources.ErrorContextUnknownAction);
-                }
-            }
-            finally
-            {
-                this.IsProcessing = false;
+                default:
+                    throw new ArgumentOutOfRangeException("actionId", actionId, Resources.ErrorContextUnknownAction);
             }
         }
 
@@ -267,33 +253,14 @@ namespace Origam.Server
 
         private object Refresh()
         {
-            try
-            {
-                this.IsProcessing = true;
-
-                this.Clear();
-            }
-            finally
-            {
-                this.IsProcessing = false;
-            }
-
+            this.Clear();
             LoadData();
-
             return this.Data;
         }
 
         #endregion
 
         #region Properties
-        private bool _isProcessing;
-
-        public bool IsProcessing
-        {
-            get { return _isProcessing; }
-            set { _isProcessing = value; }
-        }
-	
         public Guid DataStructureId
         {
             get { return _dataStructureId; }

--- a/backend/Origam.Server/Session Stores/WorkQueueSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/WorkQueueSessionStore.cs
@@ -158,7 +158,7 @@ namespace Origam.Server
             PrepareData();
         }
 
-        public override object ExecuteAction(string actionId)
+        public override object ExecuteActionInternal(string actionId)
         {
             switch (actionId)
             {

--- a/backend/Origam.Server/Session Stores/WorkflowSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/WorkflowSessionStore.cs
@@ -79,7 +79,6 @@ namespace Origam.Server
         private DataStructureMethod _refreshMethod;
         private Hashtable _parameters = new Hashtable();
         private bool _allowSave;
-        private bool _isProcessing;
         private bool _isFinalForm;
         private bool _isAutoNext;
         private bool _isFirstSaveDone = false;
@@ -114,54 +113,34 @@ namespace Origam.Server
             HandleWorkflow(handler);
         }
 
-        public override object ExecuteAction(string actionId)
-        {
-            return ExecuteAction(actionId, null);
-        }
-
-        public object ExecuteAction(string actionId, IList<string> cachedFormIds)
+        public override object ExecuteActionInternal(string actionId)
         {
             object result;
-
-            if (this.IsProcessing)
+            switch (actionId)
             {
-                throw new Exception(Resources.ErrorCommandInProgress);
-            }
+                case ACTION_QUERYNEXT:
+                    result = EvaluateEndRule();
+                    break;
 
-            this.IsProcessing = true;
+                case ACTION_NEXT:
+                    result = HandleWorkflowNextAsync().Result;
+                    break;
 
-            try
-            {
-                switch (actionId)
-                {
-                    case ACTION_QUERYNEXT:
-                        result = EvaluateEndRule();
-                        break;
+                case ACTION_ABORT:
+                    result = HandleAbortAsync().Result;
+                    break;
 
-                    case ACTION_NEXT:
-                        result = HandleWorkflowNextAsync(cachedFormIds).Result;
-                        break;
+                case ACTION_SAVE:
+                    result = this.Save();
+                    this.IsFirstSaveDone = true;
+                    break;
 
-                    case ACTION_ABORT:
-                        result = HandleAbortAsync().Result;
-                        break;
+                case ACTION_REFRESH:
+                    result = this.HandleRefresh();
+                    break;
 
-                    case ACTION_SAVE:
-                        result = this.Save();
-                        this.IsFirstSaveDone = true;
-                        break;
-
-                    case ACTION_REFRESH:
-                        result = this.HandleRefresh();
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException("actionId", actionId, Resources.ErrorContextUnknownAction);
-                }
-            }
-            finally
-            {
-                this.IsProcessing = false;
+                default:
+                    throw new ArgumentOutOfRangeException("actionId", actionId, Resources.ErrorContextUnknownAction);
             }
 
             if (_disposeAfterAction)
@@ -330,12 +309,6 @@ namespace Origam.Server
         {
             get { return _finishMessage; }
             set { _finishMessage = value; }
-        }
-
-        public bool IsProcessing
-        {
-            get { return _isProcessing; }
-            set { _isProcessing = value; }
         }
 
         public bool IsFirstSaveDone
@@ -533,7 +506,7 @@ namespace Origam.Server
             return new RuleExceptionDataCollection() ;
         }
 
-        private async System.Threading.Tasks.Task<UIResult> HandleWorkflowNextAsync(IList<string> cachedWorkflowTaskIds)
+        private async System.Threading.Tasks.Task<UIResult> HandleWorkflowNextAsync()
         {
             RuleExceptionDataCollection results = EvaluateEndRule();
             if (results != null)
@@ -557,7 +530,7 @@ namespace Origam.Server
             this.Host.FinishWorkflowForm(this.TaskId, this.XmlData);
             handler.Event.WaitOne();
             HandleWorkflow(handler);
-            UIRequest request = GetRequest(cachedWorkflowTaskIds);
+            UIRequest request = GetRequest();
             UIResult result = this.Service.InitUI(request);
             result.WorkflowTaskId = this.TaskId.ToString();
             await System.Threading.Tasks.Task.CompletedTask; //CS1998
@@ -591,11 +564,11 @@ namespace Origam.Server
             HandleWorkflow(handler);
             await System.Threading.Tasks.Task.CompletedTask; //CS1998
             // call InitUI
-            UIRequest request = GetRequest(null);
+            UIRequest request = GetRequest();
             return Service.InitUI(request);
         }
 
-        private UIRequest GetRequest(IList<string> cachedWorkflowTaskIds)
+        private UIRequest GetRequest()
         {
             bool die = (this.FormId == new Guid(Origam.OrigamEngine.ModelXmlBuilders.FormXmlBuilder.WORKFLOW_FINISHED_FORMID));
             SessionStore ss;
@@ -615,10 +588,7 @@ namespace Origam.Server
             request.IsStandalone = ss.Request.IsStandalone;
             request.ObjectId = ss.Request.ObjectId;
             request.IsNewSession = false;
-            if (cachedWorkflowTaskIds != null)
-            {
-                request.IsDataOnly = cachedWorkflowTaskIds.Contains(this.TaskId.ToString());
-            }
+            request.IsDataOnly = false;
             return request;
         }
         #endregion


### PR DESCRIPTION

* Added forgotten locks to session store. It used to happen to execute an action when long running UpdateObject was still processing. Without lock protection it led to unpredictable results.
* Secured all SessionStore.ExecueAction with lock and "already running" protection.
* Removed unused CachedFormIds, backward compatible API change.