### PR TITLE
FEATURE: Application name removed form log out message

### DIFF
--- a/backend/Origam.Server/Views/Account/LoggedOut.cshtml
+++ b/backend/Origam.Server/Views/Account/LoggedOut.cshtml
@@ -18,7 +18,7 @@
 {
     <div class="login-link">
         @SharedLocalizer["ReturnToApplication1"]<a class="in-page-link" href="@Model.PostLogoutRedirectUri">@SharedLocalizer["ReturnToApplication2"]</a>@SharedLocalizer["ReturnToApplication3"]
-        <span>@Model.ClientName@(string.IsNullOrEmpty(Model.ClientName) ? "" :  " ")</span>@SharedLocalizer["ReturnToApplication4"]
+        @SharedLocalizer["ReturnToApplication4"]
     </div>
 }
 else


### PR DESCRIPTION
Application name removed from log out message. It was always `origamWebClient` for external web applications.