### PR TITLE
FIX: Architect starts with error

### DIFF
--- a/backend/OrigamSetup/config/OrigamArchitect.exe.config
+++ b/backend/OrigamSetup/config/OrigamArchitect.exe.config
@@ -139,5 +139,12 @@
 			<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
 		</dependentAssembly>
 	</assemblyBinding>
+	<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+	<dependentAssembly>
+		<assemblyIdentity name="MoreLINQ" culture="neutral"
+						  publicKeyToken="384d532d7e88985d"/>
+		<bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+	</dependentAssembly>
+	</assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Could not load file or assembly 'MoreLinq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=384d532d7e88985d'