### PR TITLE
FIX: Extra RowState requests collided with WorkflowNextQuery requests 2023.2

### DIFF
--- a/backend/Origam.Server/Session Stores/SessionStore.cs
+++ b/backend/Origam.Server/Session Stores/SessionStore.cs
@@ -945,14 +945,20 @@ namespace Origam.Server
                 false);
         }
 
+        protected virtual bool GetMoreChanges(List<ChangeInfo> changes)
+        {
+            // Optimization. There are cases when calling UpdateObject can result
+            // in a lot of changes and a lot of row states. This should reduce size
+            // of the returned data and improve the UpdateObject's time.
+            // The missing row states should be loaded by the client.
+            return changes.Count < 20;
+        }
+
         private void GetChangesRecursive(List<ChangeInfo> changes, string requestingGrid, DataRow row, Operation operation, DataRow changedRow, bool allDetails, Hashtable ignoreKeys, bool includeRowStates)
         {
             if (row.RowState != DataRowState.Deleted && row.RowState != DataRowState.Detached)
             {
-                // Optimization. There are cases when calling UpdateObject can result in a lot of changes and a lot of
-                // row states. This should reduce size of the returned data and improve the UpdateObject's time.
-                // The missing row states should be loaded by the client.
-                includeRowStates = includeRowStates && changes.Count < 20;
+                includeRowStates = includeRowStates && GetMoreChanges(changes);
                 
                 object rowKey = DatasetTools.PrimaryKey(row)[0];
                 string ignoreRowIndex = row.Table.TableName + rowKey.ToString();

--- a/backend/Origam.Server/Session Stores/WorkflowSessionStore.cs
+++ b/backend/Origam.Server/Session Stores/WorkflowSessionStore.cs
@@ -592,5 +592,12 @@ namespace Origam.Server
             return request;
         }
         #endregion
+        protected override bool GetMoreChanges(List<ChangeInfo> changes)
+        {
+            // Limit imposed in the SessionStore for optimization reasons is
+            // removed here to avoid collisions between RowStates and WorkflowNextQuery
+            // requests
+            return true; 
+        }
     }
 }


### PR DESCRIPTION
if the user types quickly and then presses next button in a work flow screen.