### PR TITLE
FIX: Could not load file or assembly MoreLinq

### DIFF
--- a/backend/Origam.DA.Service-net2Tests/App.config
+++ b/backend/Origam.DA.Service-net2Tests/App.config
@@ -72,5 +72,12 @@
         <bindingRedirect oldVersion="0.0.0.0-0.86.0.518" newVersion="0.86.0.518"/>
       </dependentAssembly>
     </assemblyBinding>
+	  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+		  <dependentAssembly>
+			  <assemblyIdentity name="MoreLINQ" culture="neutral"
+								publicKeyToken="384d532d7e88985d"/>
+			  <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
+		  </dependentAssembly>
+	  </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
Fixed:  System.IO.FileLoadException : Could not load file or assembly 'MoreLinq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=384d532d7e88985d' or one of its dependencies.