### PR TITLE
FIX: Focus was moved back to the original input after pressing the "Next" …

### DIFF
--- a/frontend-html/src/model/entities/FormScreenLifecycle/FormScreenLifecycle.tsx
+++ b/frontend-html/src/model/entities/FormScreenLifecycle/FormScreenLifecycle.tsx
@@ -840,8 +840,6 @@ export class FormScreenLifecycle02 implements IFormScreenLifecycle02 {
       yield*clearRowStates(dataView)();
       yield*processCRUDResult(dataView, updateObjectResult, false, dataView);
     }
-    dataView.formFocusManager.refocusLast();
-
     return true;
   }
 


### PR DESCRIPTION
…key on mobile keyboards

It looks like the Next key press cannot be intercepted in javascript. The problem was that the lastFocused item was not updated so the previous one was focused after UpdateObject.