### PR TITLE
FIX: Groups below the first grouping level were missing labels 2024.1

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Table/TableRendering/GroupItem.ts
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/TableRendering/GroupItem.ts
@@ -39,7 +39,7 @@ export interface IGroupItemData {
   childRows: any[][];
   columnId: string;
   columnValue: string;
-  columnDisplayValue: string;
+  getColumnDisplayValue: () => string;
   groupLabel: string;
   parent: IGroupTreeNode | undefined;
   rowCount: number;
@@ -69,7 +69,7 @@ export class ClientSideGroupItem implements IClientSideGroupItemData, IGroupTree
   groupLabel: string = null as any;
   parent: IGroupTreeNode | undefined = null as any;
   rowCount: number = null as any;
-  columnDisplayValue: string = null as any;
+  getColumnDisplayValue: () => string = null as any;
   aggregations: IAggregation[] | undefined = undefined;
   grouper: IGrouper = null as any;
   groupFilters: string[] = [];
@@ -158,7 +158,7 @@ export class ServerSideGroupItem implements IGroupTreeNode {
   groupLabel: string = null as any;
   parent: IGroupTreeNode | undefined = null as any;
   rowCount: number = null as any;
-  columnDisplayValue: string = null as any;
+  getColumnDisplayValue: () => string = null as any;
   aggregations: IAggregation[] | undefined = undefined;
   grouper: IGrouper = null as any;
   scrollLoader: InfiniteScrollLoader;

--- a/frontend-html/src/gui/Components/ScreenElements/Table/TableRendering/tableRows.ts
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/TableRendering/tableRows.ts
@@ -30,7 +30,7 @@ export class TableGroupRow implements IGroupRow {
   }
 
   get columnValue(): string {
-    return this.sourceGroup.columnDisplayValue;
+    return this.sourceGroup.getColumnDisplayValue();
   }
 
   get isExpanded(): boolean {

--- a/frontend-html/src/gui/Components/ScreenElements/Table/TableRendering/types.ts
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/TableRendering/types.ts
@@ -47,7 +47,7 @@ export interface IGroupTreeNode {
   isExpanded: boolean;
   rowCount: number;
   columnValue: string;
-  columnDisplayValue: string;
+  getColumnDisplayValue: () => string;
   aggregations: IAggregation[] | undefined;
   allParents: IGroupTreeNode[];
 

--- a/frontend-html/src/model/entities/ClientSideGrouper.ts
+++ b/frontend-html/src/model/entities/ClientSideGrouper.ts
@@ -84,7 +84,7 @@ export class ClientSideGrouper implements IGrouper {
 
   loadRecursively(groups: IGroupTreeNode[]) {
     for (let group of groups) {
-      if (this.expandedGroupDisplayValues.has(group.columnDisplayValue)) {
+      if (this.expandedGroupDisplayValues.has(group.getColumnDisplayValue())) {
         group.isExpanded = true;
         this.loadChildrenInternal(group);
         this.loadRecursively(group.childGroups);
@@ -94,9 +94,9 @@ export class ClientSideGrouper implements IGrouper {
 
   expansionListener(item: ClientSideGroupItem) {
     if (item.isExpanded) {
-      this.expandedGroupDisplayValues.add(item.columnDisplayValue);
+      this.expandedGroupDisplayValues.add(item.getColumnDisplayValue());
     } else {
-      this.expandedGroupDisplayValues.delete(item.columnDisplayValue);
+      this.expandedGroupDisplayValues.delete(item.getColumnDisplayValue());
     }
   }
 
@@ -123,7 +123,7 @@ export class ClientSideGrouper implements IGrouper {
           rowCount: groupData.rows.length,
           parent: parent,
           columnValue: groupData.label,
-          columnDisplayValue: property ? dataTable.resolveCellText(property, groupData.label) : groupData.label,
+          getColumnDisplayValue: () => property ? dataTable.resolveCellText(property, groupData.label) : groupData.label,
           aggregations: this.calcAggregations(groupData.rows),
           grouper: this,
           expansionListener: this.expansionListener.bind(this)

--- a/frontend-html/src/model/entities/ServerSideGrouper.ts
+++ b/frontend-html/src/model/entities/ServerSideGrouper.ts
@@ -77,7 +77,7 @@ export class ServerSideGrouper implements IGrouper {
     }
     const expandedGroupDisplayValues = this.allGroups
       .filter(group => group.isExpanded)
-      .map(group => group.columnDisplayValue)
+      .map(group => group.getColumnDisplayValue())
     const dataView = getDataView(this);
     const property = getDataTable(this).getPropertyById(firstGroupingColumn.columnId);
     const lookupId = property && property.lookup && property.lookup.lookupId;
@@ -89,7 +89,7 @@ export class ServerSideGrouper implements IGrouper {
 
   private*loadAndExpandChildren(childGroups: IGroupTreeNode[], expandedGroupDisplayValues: string[]): Generator {
     for (const group of childGroups) {
-      if (expandedGroupDisplayValues.includes(group.columnDisplayValue)) {
+      if (expandedGroupDisplayValues.includes(group.getColumnDisplayValue())) {
         group.isExpanded = true;
         yield*this.loadChildren(group);
         yield*this.loadAndExpandChildren(group.childGroups, expandedGroupDisplayValues)
@@ -214,7 +214,7 @@ export class ServerSideGrouper implements IGrouper {
         rowCount: groupDataItem["groupCount"] as number,
         parent: parent,
         columnValue: groupData.value,
-        columnDisplayValue: groupData.label,
+        getColumnDisplayValue: () => groupData.label,
         aggregations: parseAggregations(groupDataItem["aggregations"]),
         groupingUnit: groupingSettings.groupingUnit,
         grouper: this,

--- a/frontend-html/src/modules/Lookup/LookupResolver.ts
+++ b/frontend-html/src/modules/Lookup/LookupResolver.ts
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { action, createAtom, IAtom } from "mobx";
+import { action, createAtom, IAtom, observable } from "mobx";
 import _ from "lodash";
 import { LookupCacheIndividual } from "./LookupCacheIndividual";
 import { ILookupIndividualResultListenerArgs, LookupLoaderIndividual, } from "./LookupLoaderIndividual";
@@ -27,6 +27,7 @@ export class LookupResolver {
   constructor(private cache: LookupCacheIndividual, private loader: LookupLoaderIndividual) {
   }
 
+  @observable
   resolved = new Map<any, any>();
   atoms = new Map<any, IAtom>();
 


### PR DESCRIPTION
<empty> was displayed instead of the grouped column name.