### PR TITLE
FIX: Download file doesn't work if blob member is not specified

### DIFF
--- a/backend/Origam.Server/Controller/BlobController.cs
+++ b/backend/Origam.Server/Controller/BlobController.cs
@@ -94,7 +94,7 @@ namespace Origam.Server.Controller
                 Stream resultStream;
                 MemoryStream memoryStream;
                 var processBlobField 
-                    = string.IsNullOrEmpty(blobDownloadRequest.BlobMember) 
+                    = !string.IsNullOrEmpty(blobDownloadRequest.BlobMember) 
                       && (blobDownloadRequest.Row[
                               blobDownloadRequest.BlobMember] != DBNull.Value);
                 if((blobDownloadRequest.BlobLookupId != Guid.Empty) 


### PR DESCRIPTION
FIX #3319: https://community.origam.com/t/cannot-open-attachment-via-lookup-from-sd-data-structure-because-it-does-not-contain-blob-column/3319

* Fix to open file even when any BLOB field is not available inside the data structure.