### PR TITLE
UX - Standardize cursor behavior when hovering over editors

### DIFF
--- a/frontend-html/public/locale/localization_cs-CZ.json
+++ b/frontend-html/public/locale/localization_cs-CZ.json
@@ -146,5 +146,6 @@
   "order_columns_button": "Seřadit",
   "order_columns_title": "Pořadí sloupců",
   "add_new_record": "Přidat nový záznam",
-  "cancel_workflow_confirmation": "Opravdu chcete zrušit workflow?"
+  "cancel_workflow_confirmation": "Opravdu chcete zrušit workflow?",
+  "hold_ctrl_tool_tip": "Držte klávesu Ctrl a klikněte pro otevření odkazu"
 }

--- a/frontend-html/public/locale/localization_de-CH.json
+++ b/frontend-html/public/locale/localization_de-CH.json
@@ -141,5 +141,6 @@
   "column_width": "Breite",
   "order_columns_button": "Sortieren",
   "order_columns_title": "Spalten sortieren",
-  "add_new_record": "Neuer Datensatz"
+  "add_new_record": "Neuer Datensatz",
+  "hold_ctrl_tool_tip": "Ctrl-Taste gedrückt halten und klicken, um den Link zu öffnen"
 }

--- a/frontend-html/public/locale/localization_de-DE.json
+++ b/frontend-html/public/locale/localization_de-DE.json
@@ -141,5 +141,6 @@
   "column_width": "Breite",
   "order_columns_button": "Sortieren",
   "order_columns_title": "Spalten sortieren",
-  "add_new_record": "Neuer Datensatz"
+  "add_new_record": "Neuer Datensatz",
+  "hold_ctrl_tool_tip": "Ctrl-Taste gedrückt halten und klicken, um den Link zu öffnen"
 }

--- a/frontend-html/public/locale/localization_en-US.json
+++ b/frontend-html/public/locale/localization_en-US.json
@@ -142,5 +142,6 @@
   "order_columns_button": "Order",
   "order_columns_title": "Order Columns",
   "add_new_record": "Add New Record",
-  "cancel_workflow_confirmation": "Are you sure you want to cancel the workflow?"
+  "cancel_workflow_confirmation": "Are you sure you want to cancel the workflow?",
+  "hold_ctrl_tool_tip": "Hold Ctrl and click to open link"
 }

--- a/frontend-html/public/locale/localization_fr-CH.json
+++ b/frontend-html/public/locale/localization_fr-CH.json
@@ -130,5 +130,6 @@
   "order_columns_button": "organiser",
   "order_columns_title": "organiser les colonnes",
   "add_new_record": "Ajouter nouveau dossier",
-  "cancel_workflow_confirmation": "Êtes-vous certain de vouloir annuler le flux de travail?"
+  "cancel_workflow_confirmation": "Êtes-vous certain de vouloir annuler le flux de travail?",
+  "hold_ctrl_tool_tip": "Maintenez Ctrl enfoncé et cliquez pour ouvrir le lien"
 }

--- a/frontend-html/src/gui/Components/Dropdown/Dropdown.module.scss
+++ b/frontend-html/src/gui/Components/Dropdown/Dropdown.module.scss
@@ -163,8 +163,10 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 }
 
 .input {
+  color: var(--foreground1) !important;
+  cursor: text;
+
   &:global(.isLink) {
-    color: var(--foreground1) !important;
     cursor: pointer !important;
   }
 }

--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
@@ -77,7 +77,7 @@ export function DropdownEditorInput(props: {
       {() => (
         <input
           className={cx("input", S.input, (ctrlKeyPressed && setup.isLink) ? ["isLink", S.isLink] : "")}
-          title={T("Hold Ctrl and click to open link", "hold_ctrl_tool_tip")}
+          title={setup.isLink ? T("Hold Ctrl and click to open link", "hold_ctrl_tool_tip") : ""}
           readOnly={beh.isReadOnly}
           ref={refInput}
           placeholder={data.isResolving ? "Loading..." : ""}

--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
@@ -22,6 +22,7 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import { CtxDropdownEditor } from "./DropdownEditor";
 import cx from 'classnames';
 import S from "gui/Components/Dropdown/Dropdown.module.scss";
+import { T } from "utils/translation";
 
 export function DropdownEditorInput(props: {
   backgroundColor?: string;
@@ -76,6 +77,7 @@ export function DropdownEditorInput(props: {
       {() => (
         <input
           className={cx("input", S.input, (ctrlKeyPressed && setup.isLink) ? ["isLink", S.isLink] : "")}
+          title={T("Hold Ctrl and click to open link", "hold_ctrl_tool_tip")}
           readOnly={beh.isReadOnly}
           ref={refInput}
           placeholder={data.isResolving ? "Loading..." : ""}

--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
@@ -18,7 +18,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Observer } from "mobx-react";
-import React, { useContext, useEffect, useMemo } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 import { CtxDropdownEditor } from "./DropdownEditor";
 import cx from 'classnames';
 import S from "gui/Components/Dropdown/Dropdown.module.scss";
@@ -31,6 +31,7 @@ export function DropdownEditorInput(props: {
   const beh = useContext(CtxDropdownEditor).behavior;
   const data = useContext(CtxDropdownEditor).editorData;
   const setup = useContext(CtxDropdownEditor).setup;
+  const [ctrlKeyPressed, setCtrlKeyPressed] = useState<boolean>(false);
   const refInput = useMemo(() => {
     return (elm: any) => {
       beh.refInputElement(elm);
@@ -60,12 +61,21 @@ export function DropdownEditorInput(props: {
     }
   }
 
+  document.addEventListener('keydown', function(event) {
+    if (event.ctrlKey)
+      setCtrlKeyPressed(true)
+  });
+  
+  document.addEventListener('keyup', function(event) {
+    if (!event.ctrlKey)
+      setCtrlKeyPressed(false)
+  });
 
   return (
     <Observer>
       {() => (
         <input
-          className={cx("input", S.input, {isLink: setup.isLink})}
+          className={cx("input", S.input, ctrlKeyPressed ? ["isLink", S.isLink] : "")}
           readOnly={beh.isReadOnly}
           ref={refInput}
           placeholder={data.isResolving ? "Loading..." : ""}

--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
@@ -75,7 +75,7 @@ export function DropdownEditorInput(props: {
     <Observer>
       {() => (
         <input
-          className={cx("input", S.input, ctrlKeyPressed ? ["isLink", S.isLink] : "")}
+          className={cx("input", S.input, (ctrlKeyPressed && setup.isLink) ? ["isLink", S.isLink] : "")}
           readOnly={beh.isReadOnly}
           ref={refInput}
           placeholder={data.isResolving ? "Loading..." : ""}

--- a/model-tests/model/Widgets/Menu/Menu.origam
+++ b/model-tests/model/Widgets/Menu/Menu.origam
@@ -211,7 +211,7 @@
       <frmi:MenuItem
         asi:abstract="false"
         frmi:autoSaveOnListRecordChange="false"
-        ami:displayName="Dropdown Search By First ColumnO nly"
+        ami:displayName="Dropdown Search By First Column Only"
         x:id="d28dfa42-c298-4705-9ba6-c3e88c15abd0"
         asi:name="WidgetDropdownTest_MultiColumn_SearchByFirstColumnOnly"
         ami:openExclusively="false"


### PR DESCRIPTION
Changed the default cursor icon from 'pointer' to 'text' when hovering over selected text in a dropdown. When hovering over the text, a tooltip about holding the Ctrl key and clicking the text will show up (in case the text is a link). While holding the key, the cursor icon will switch to 'pointer'. If the text is not a link, then the tooltip will stay hidden. Also, the tooltip message is being translated based on the currently used language.