### PR TITLE
FIX: Dropdown after double clicking a read-only lookup

### DIFF
--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorBehavior.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorBehavior.tsx
@@ -131,6 +131,9 @@ export class DropdownEditorBehavior implements IDropdownEditorBehavior {
   willLoadNextPage = true;
 
   public handleDoubleClick(event: any){
+    if (this.isReadOnly) {
+      return;
+    }
     this.onDoubleClick?.(event);
     this.dropDown();
   }


### PR DESCRIPTION
Fixed dropdown showing up after double clicking a read-only lookup field.