### PR TITLE
FIX: Show Record Information not updated with arrows

### DIFF
--- a/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
@@ -29,7 +29,6 @@ import { shouldProceedToChangeRow } from "./shouldProceedToChangeRow";
 import uiActions from "../../../actions-ui-tree";
 import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
-import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
 import { getMenuItemId } from "model/selectors/getMenuItemId";
 import { getSessionId } from "model/selectors/getSessionId";
 
@@ -48,7 +47,7 @@ export function onTableKeyDown(ctx: any) {
           yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
             getMenuItemId(dataView),
             getDataStructureEntityId(dataView),
-            getSelectedRowId(ctx),
+            dataView.selectedRowId,
             getSessionId(dataView)
           );
 
@@ -64,7 +63,7 @@ export function onTableKeyDown(ctx: any) {
           yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
             getMenuItemId(dataView),
             getDataStructureEntityId(dataView),
-            getSelectedRowId(ctx),
+            dataView.selectedRowId,
             getSessionId(dataView)
           );
 

--- a/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
@@ -27,6 +27,11 @@ import { handleError } from "model/actions/handleError";
 import { getDataView } from "model/selectors/DataView/getDataView";
 import { shouldProceedToChangeRow } from "./shouldProceedToChangeRow";
 import uiActions from "../../../actions-ui-tree";
+import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
+import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
+import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
+import { getMenuItemId } from "model/selectors/getMenuItemId";
+import { getSessionId } from "model/selectors/getSessionId";
 
 export function onTableKeyDown(ctx: any) {
   return flow(function*onTableKeyDown(event: any) {
@@ -39,6 +44,14 @@ export function onTableKeyDown(ctx: any) {
             break;
           }
           yield*selectPrevRow(ctx)();
+
+          yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
+            getMenuItemId(dataView),
+            getDataStructureEntityId(dataView),
+            getSelectedRowId(ctx),
+            getSessionId(dataView)
+          );
+
           getTablePanelView(ctx).scrollToCurrentCell();
           break;
         case "ArrowDown":
@@ -47,6 +60,14 @@ export function onTableKeyDown(ctx: any) {
             break;
           }
           yield*selectNextRow(ctx)();
+
+          yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
+            getMenuItemId(dataView),
+            getDataStructureEntityId(dataView),
+            getSelectedRowId(ctx),
+            getSessionId(dataView)
+          );
+
           getTablePanelView(ctx).scrollToCurrentCell();
           break;
         case "F2":

--- a/frontend-html/src/model/actions-ui/DataView/onFirstRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onFirstRowClick.ts
@@ -27,7 +27,6 @@ import { getDataStructureEntityId } from "model/selectors/DataView/getDataStruct
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
 import { getMenuItemId } from "model/selectors/getMenuItemId";
 import { getSessionId } from "model/selectors/getSessionId";
-import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
 
 export function onFirstRowClick(ctx: any) {
   return flow(function*onFirstRowClick(event: any) {
@@ -42,7 +41,7 @@ export function onFirstRowClick(ctx: any) {
       yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
         getMenuItemId(dataView),
         getDataStructureEntityId(dataView),
-        getSelectedRowId(ctx),
+        dataView.selectedRowId,
         getSessionId(dataView)
       );
 

--- a/frontend-html/src/model/actions-ui/DataView/onFirstRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onFirstRowClick.ts
@@ -23,9 +23,14 @@ import { handleError } from "../../actions/handleError";
 import { getFocusManager } from "model/selectors/getFocusManager";
 import { shouldProceedToChangeRow } from "model/actions-ui/DataView/TableView/shouldProceedToChangeRow";
 import { getDataView } from "model/selectors/DataView/getDataView";
+import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
+import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
+import { getMenuItemId } from "model/selectors/getMenuItemId";
+import { getSessionId } from "model/selectors/getSessionId";
+import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
 
 export function onFirstRowClick(ctx: any) {
-  return flow(function*onPrevRowClick(event: any) {
+  return flow(function*onFirstRowClick(event: any) {
     try {
       const focusManager = getFocusManager(ctx);
       yield focusManager.activeEditorCloses();
@@ -34,6 +39,13 @@ export function onFirstRowClick(ctx: any) {
         return;
       }
       yield*selectFirstRow(ctx)();
+      yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
+        getMenuItemId(dataView),
+        getDataStructureEntityId(dataView),
+        getSelectedRowId(ctx),
+        getSessionId(dataView)
+      );
+
     } catch (e) {
       yield*handleError(ctx)(e);
       throw e;

--- a/frontend-html/src/model/actions-ui/DataView/onLastRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onLastRowClick.ts
@@ -23,6 +23,11 @@ import { handleError } from "../../actions/handleError";
 import { getFocusManager } from "model/selectors/getFocusManager";
 import { getDataView } from "model/selectors/DataView/getDataView";
 import { shouldProceedToChangeRow } from "model/actions-ui/DataView/TableView/shouldProceedToChangeRow";
+import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
+import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
+import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
+import { getMenuItemId } from "model/selectors/getMenuItemId";
+import { getSessionId } from "model/selectors/getSessionId";
 
 export function onLastRowClick(ctx: any) {
   return flow(function*onLastRowClick(event: any) {
@@ -34,6 +39,13 @@ export function onLastRowClick(ctx: any) {
         return;
       }
       yield*selectLastRow(ctx)();
+      yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
+        getMenuItemId(dataView),
+        getDataStructureEntityId(dataView),
+        getSelectedRowId(ctx),
+        getSessionId(dataView)
+      );
+
     } catch (e) {
       yield*handleError(ctx)(e);
       throw e;

--- a/frontend-html/src/model/actions-ui/DataView/onLastRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onLastRowClick.ts
@@ -25,7 +25,6 @@ import { getDataView } from "model/selectors/DataView/getDataView";
 import { shouldProceedToChangeRow } from "model/actions-ui/DataView/TableView/shouldProceedToChangeRow";
 import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
-import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
 import { getMenuItemId } from "model/selectors/getMenuItemId";
 import { getSessionId } from "model/selectors/getSessionId";
 
@@ -42,7 +41,7 @@ export function onLastRowClick(ctx: any) {
       yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
         getMenuItemId(dataView),
         getDataStructureEntityId(dataView),
-        getSelectedRowId(ctx),
+        dataView.selectedRowId,
         getSessionId(dataView)
       );
 

--- a/frontend-html/src/model/actions-ui/DataView/onNextRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onNextRowClick.ts
@@ -26,7 +26,6 @@ import { getGridFocusManager } from "model/entities/GridFocusManager";
 import { getFocusManager } from "model/selectors/getFocusManager";
 import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
-import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
 import { getMenuItemId } from "model/selectors/getMenuItemId";
 import { getSessionId } from "model/selectors/getSessionId";
 
@@ -43,7 +42,7 @@ export function onNextRowClick(ctx: any) {
       yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
         getMenuItemId(dataView),
         getDataStructureEntityId(dataView),
-        getSelectedRowId(ctx),
+        dataView.selectedRowId,
         getSessionId(dataView)
       );
 

--- a/frontend-html/src/model/actions-ui/DataView/onNextRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onNextRowClick.ts
@@ -24,6 +24,11 @@ import { getDataView } from "model/selectors/DataView/getDataView";
 import { shouldProceedToChangeRow } from "./TableView/shouldProceedToChangeRow";
 import { getGridFocusManager } from "model/entities/GridFocusManager";
 import { getFocusManager } from "model/selectors/getFocusManager";
+import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
+import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
+import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
+import { getMenuItemId } from "model/selectors/getMenuItemId";
+import { getSessionId } from "model/selectors/getSessionId";
 
 export function onNextRowClick(ctx: any) {
   return flow(function*onNextRowClick(event: any) {
@@ -35,6 +40,13 @@ export function onNextRowClick(ctx: any) {
         return;
       }
       yield*selectNextRow(ctx)();
+      yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
+        getMenuItemId(dataView),
+        getDataStructureEntityId(dataView),
+        getSelectedRowId(ctx),
+        getSessionId(dataView)
+      );
+
     } catch (e) {
       yield*handleError(ctx)(e);
       throw e;

--- a/frontend-html/src/model/actions-ui/DataView/onPrevRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onPrevRowClick.ts
@@ -23,6 +23,11 @@ import { handleError } from "model/actions/handleError";
 import { getDataView } from "model/selectors/DataView/getDataView";
 import { shouldProceedToChangeRow } from "./TableView/shouldProceedToChangeRow";
 import { getFocusManager } from "model/selectors/getFocusManager";
+import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
+import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
+import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
+import { getMenuItemId } from "model/selectors/getMenuItemId";
+import { getSessionId } from "model/selectors/getSessionId";
 
 export function onPrevRowClick(ctx: any) {
   return flow(function*onPrevRowClick(event: any) {
@@ -34,6 +39,13 @@ export function onPrevRowClick(ctx: any) {
         return;
       }
       yield*selectPrevRow(ctx)();
+      yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
+        getMenuItemId(dataView),
+        getDataStructureEntityId(dataView),
+        getSelectedRowId(ctx),
+        getSessionId(dataView)
+      );
+
     } catch (e) {
       yield*handleError(ctx)(e);
       throw e;

--- a/frontend-html/src/model/actions-ui/DataView/onPrevRowClick.ts
+++ b/frontend-html/src/model/actions-ui/DataView/onPrevRowClick.ts
@@ -25,7 +25,6 @@ import { shouldProceedToChangeRow } from "./TableView/shouldProceedToChangeRow";
 import { getFocusManager } from "model/selectors/getFocusManager";
 import { getDataStructureEntityId } from "model/selectors/DataView/getDataStructureEntityId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
-import { getSelectedRowId } from "model/selectors/TablePanelView/getSelectedRowId";
 import { getMenuItemId } from "model/selectors/getMenuItemId";
 import { getSessionId } from "model/selectors/getSessionId";
 
@@ -42,7 +41,7 @@ export function onPrevRowClick(ctx: any) {
       yield*getRecordInfo(dataView).onSelectedRowMaybeChanged(
         getMenuItemId(dataView),
         getDataStructureEntityId(dataView),
-        getSelectedRowId(ctx),
+        dataView.selectedRowId,
         getSessionId(dataView)
       );
 


### PR DESCRIPTION
Fixed Record Information not being updated when switching between rows. It should now work both using arrow icons in the data view header as well as the keyboard up and down arrows.