### PR TITLE
FIX: Modifying a row on a lazy loaded screen and pressing enter sometimes resulted in record not saved error

### DIFF
--- a/frontend-html/src/modules/DataView/DataViewData.ts
+++ b/frontend-html/src/modules/DataView/DataViewData.ts
@@ -21,6 +21,7 @@ import { TypeSymbol } from "dic/Container";
 import { IDataTable } from "model/entities/types/IDataTable";
 import { IProperty } from "model/entities/types/IProperty";
 import { onFieldChange } from "model/actions-ui/DataView/TableView/onFieldChange";
+import {runInFlowWithHandler} from "../../utils/runInFlowWithHandler";
 
 export class DataViewData {
   constructor(
@@ -58,12 +59,16 @@ export class DataViewData {
     const row = dataTable.getRowById(rowId);
     const property = this.propertyById(propertyId);
     if (property && row) {
-      onFieldChange(property)({
-        event: undefined,
-        row: row,
-        property: property,
-        value: value,
-      });
+      runInFlowWithHandler({
+        ctx: this.dataTable(),
+        action: async () =>
+          await onFieldChange(property)({
+            event: undefined,
+            row: row,
+            property: property,
+            value: value,
+          })
+       });
     }
   }
 }

--- a/frontend-html/src/modules/DataView/DataViewData.ts
+++ b/frontend-html/src/modules/DataView/DataViewData.ts
@@ -21,7 +21,7 @@ import { TypeSymbol } from "dic/Container";
 import { IDataTable } from "model/entities/types/IDataTable";
 import { IProperty } from "model/entities/types/IProperty";
 import { onFieldChange } from "model/actions-ui/DataView/TableView/onFieldChange";
-import {runInFlowWithHandler} from "../../utils/runInFlowWithHandler";
+import { runInFlowWithHandler } from "utils/runInFlowWithHandler";
 
 export class DataViewData {
   constructor(


### PR DESCRIPTION
…resulted in record not saved error

Happened on MenuItems with the property RequestSaveAfterUpdate set to true.