### PR TITLE
FIX: Focus was sometimes not set to the active editor after changing a value and pressing enter twice

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Table/Scroller.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/Scroller.tsx
@@ -106,7 +106,9 @@ export default class Scroller extends React.Component<IScrollerProps> {
         console.warn("Focus was requested on an invisible table. This should not happen.");
         return;
       }
-      requestFocus(this.elmScrollerDiv);
+      if (this.props.canFocus()){
+        requestFocus(this.elmScrollerDiv);
+      }
     });
   }
 

--- a/frontend-html/src/gui/Components/ScreenElements/Table/Scroller.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/Scroller.tsx
@@ -106,7 +106,7 @@ export default class Scroller extends React.Component<IScrollerProps> {
         console.warn("Focus was requested on an invisible table. This should not happen.");
         return;
       }
-      if (this.props.canFocus()){
+      if (this.props.canFocus()) {
         requestFocus(this.elmScrollerDiv);
       }
     });

--- a/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
@@ -51,7 +51,7 @@ import { getSessionId } from "model/selectors/getSessionId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
 import { getTablePanelView } from "model/selectors/TablePanelView/getTablePanelView";
 import cx from 'classnames';
-import {getGridFocusManager} from "model/entities/GridFocusManager";
+import { getGridFocusManager } from "model/entities/GridFocusManager";
 
 function createTableRenderer(ctx: any, gridDimensions: IGridDimensions) {
   const groupedColumnSettings = computed(

--- a/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
@@ -51,6 +51,7 @@ import { getSessionId } from "model/selectors/getSessionId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
 import { getTablePanelView } from "model/selectors/TablePanelView/getTablePanelView";
 import cx from 'classnames';
+import {getGridFocusManager} from "../../../../model/entities/GridFocusManager";
 
 function createTableRenderer(ctx: any, gridDimensions: IGridDimensions) {
   const groupedColumnSettings = computed(
@@ -433,6 +434,10 @@ export class RawTable extends React.Component<ITableProps & { isVisible: boolean
     && this.tablePanelView.currentTooltipText !== undefined;
   }
 
+  canFocus(){
+    return getGridFocusManager(this.context.tablePanelView).canFocusTable;
+  }
+
   render() {
     const editorCellRectangle =
       this.props.editingRowIndex !== undefined && this.props.editingColumnIndex !== undefined
@@ -541,6 +546,7 @@ export class RawTable extends React.Component<ITableProps & { isVisible: boolean
                         onMouseLeave={(event) => this.onMouseLeaveTooltipEnabledArea(event)}
                         onKeyDown={this.props.onKeyDown}
                         onFocus={this.props.onFocus}
+                        canFocus={()=>this.canFocus()}
                       />
                     </>
                   </div>

--- a/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
@@ -51,7 +51,7 @@ import { getSessionId } from "model/selectors/getSessionId";
 import { getRecordInfo } from "model/selectors/RecordInfo/getRecordInfo";
 import { getTablePanelView } from "model/selectors/TablePanelView/getTablePanelView";
 import cx from 'classnames';
-import {getGridFocusManager} from "../../../../model/entities/GridFocusManager";
+import {getGridFocusManager} from "model/entities/GridFocusManager";
 
 function createTableRenderer(ctx: any, gridDimensions: IGridDimensions) {
   const groupedColumnSettings = computed(

--- a/frontend-html/src/gui/Components/ScreenElements/Table/types.ts
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/types.ts
@@ -178,6 +178,7 @@ export interface IScrollerProps {
   onOutsideClick?: (event: any) => void;
   onKeyDown?: (event: any) => void;
   onFocus: () => void;
+  canFocus: () => boolean;
 }
 
 export interface IScrolleeProps {

--- a/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableView.tsx
+++ b/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableView.tsx
@@ -59,9 +59,7 @@ import S from "./TableView.module.scss";
 import { isMobileLayoutActive } from "model/selectors/isMobileLayoutActive";
 import cx from "classnames";
 import { getGridFocusManager } from "model/entities/GridFocusManager";
-import {getScreenFocusManager} from "../../../../model/selectors/FormScreen/getScreenFocusManager";
-import { getTooltip } from "gui/Components/ScreenElements/Table/TableRendering/onClick";
-import { formatTooltipPlaintext } from "gui/Components/ToolTip/FormatTooltipText";
+import {getScreenFocusManager} from "model/selectors/FormScreen/getScreenFocusManager";
 
 interface ITableViewProps {
   dataView?: IDataView;

--- a/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableView.tsx
+++ b/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableView.tsx
@@ -140,10 +140,7 @@ export class TableViewInner extends React.Component<ITableViewProps & { dataView
     this.elmTable = elmTable;
     if (elmTable) {
       const d1 = this.props.tablePanelView!.subOnFocusTable(() => {
-        const gridFocusManager = getGridFocusManager(this.props.dataView);
-        if(gridFocusManager.canFocusTable){
-          elmTable.focusTable();
-        }
+        elmTable.focusTable();
       });
       const d2 = this.props.tablePanelView!.subOnScrollToCellShortest(
         elmTable.scrollToCellShortest

--- a/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableView.tsx
+++ b/frontend-html/src/gui/Workbench/ScreenArea/TableView/TableView.tsx
@@ -59,7 +59,7 @@ import S from "./TableView.module.scss";
 import { isMobileLayoutActive } from "model/selectors/isMobileLayoutActive";
 import cx from "classnames";
 import { getGridFocusManager } from "model/entities/GridFocusManager";
-import {getScreenFocusManager} from "model/selectors/FormScreen/getScreenFocusManager";
+import { getScreenFocusManager } from "model/selectors/FormScreen/getScreenFocusManager";
 
 interface ITableViewProps {
   dataView?: IDataView;

--- a/frontend-html/src/model/entities/TablePanelView/TablePanelView.tsx
+++ b/frontend-html/src/model/entities/TablePanelView/TablePanelView.tsx
@@ -433,6 +433,7 @@ export class TablePanelView implements ITablePanelView {
         if(!_this.isScrollByKeyboard) {
           _this.setEditing(false);
         }
+        _this.isScrollByKeyboard = false;
         yield*flushCurrentRowData(_this)();
       }
     })();
@@ -444,9 +445,6 @@ export class TablePanelView implements ITablePanelView {
     if (event.key === "Tab" || event.key === "Enter") {
       clearTimeout(this.hScrollDead);
       this.isScrollByKeyboard = true;
-      this.hScrollDead = setTimeout(() => {
-        this.isScrollByKeyboard = false;
-      });
     }
   }
 


### PR DESCRIPTION


Happened on lazy loaded MenuItems with the property RequestSaveAfterUpdate set to true.