### PR TITLE
FIX: Shift+Tab doesn't move focus to previous cell

### DIFF
--- a/frontend-html/src/model/actions-ui/DataView/TableView/onFieldKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onFieldKeyDown.ts
@@ -70,7 +70,7 @@ export function onFieldKeyDown(ctx: any) {
             }
 
             if (event.shiftKey) {
-              selectPrevColumn(ctx)(true);
+              yield*selectPrevColumn(ctx)(true);
             } else {
               yield*selectNextColumn(ctx)(true);
             }
@@ -83,7 +83,7 @@ export function onFieldKeyDown(ctx: any) {
             tablePanelView.triggerOnFocusTable();
           } else {
             if (event.shiftKey) {
-              selectPrevColumn(ctx)(true);
+              yield*selectPrevColumn(ctx)(true);
             } else {
               yield*selectNextColumn(ctx)(true);
             }

--- a/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
+++ b/frontend-html/src/model/actions-ui/DataView/TableView/onTableKeyDown.ts
@@ -76,7 +76,7 @@ export function onTableKeyDown(ctx: any) {
           break;
         case "Tab":
           if (event.shiftKey) {
-            selectPrevColumn(ctx)(true);
+            yield*selectPrevColumn(ctx)(true);
           } else {
             yield*selectNextColumn(ctx)(true);
           }

--- a/frontend-html/src/model/actions/DataView/TableView/selectPrevColumn.ts
+++ b/frontend-html/src/model/actions/DataView/TableView/selectPrevColumn.ts
@@ -20,7 +20,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 import { getTablePanelView } from "../../../selectors/TablePanelView/getTablePanelView";
 
 export function selectPrevColumn(ctx: any) {
-  return function selectPrevColumn(prevRowWhenStart?: boolean) {
-    getTablePanelView(ctx).selectPrevColumn(prevRowWhenStart);
+  return function* selectPrevColumn(prevRowWhenStart?: boolean) {
+    yield*getTablePanelView(ctx).selectPrevColumn(prevRowWhenStart);
   };
 }


### PR DESCRIPTION
Fixed moving focus to a previous cell after pressing Shift+Tab while editing a value.