### PR TITLE
FIX: Sql commands for dynamic filtersets were cached

### DIFF
--- a/backend/Origam.DA.Service/AbstractSqlDataService.cs
+++ b/backend/Origam.DA.Service/AbstractSqlDataService.cs
@@ -1020,7 +1020,7 @@ namespace Origam.DA.Service
 					.GetProfile(principal.Identity) as UserProfile;
 			}
 			DataStructure dataStructure = GetDataStructure(query);
-            DataStructureFilterSet filterset = GetFilterSet(query.MethodId);
+			DataStructureFilterSet filterset = GetFilterSet(query.MethodId);
             var cacheId 
 				= query.DataSourceId.ToString() 
 				  + query.MethodId.ToString() 
@@ -1034,16 +1034,16 @@ namespace Origam.DA.Service
 			}
 			else
 			{
-                command = DbDataAdapterFactory.ScalarValueCommand(
-                        dataStructure,
-                        filterset,
-                        GetSortSet(query.SortSetId),
-                        columnsInfo,
-                        query.Parameters.ToHashtable()
-                        );
+				command = DbDataAdapterFactory.ScalarValueCommand(
+						dataStructure,
+						filterset,
+						GetSortSet(query.SortSetId),
+						columnsInfo,
+						query.Parameters.ToHashtable()
+						);
 				if (!filterset.IsDynamic)
 				{
-                    lock (cache)
+					lock (cache)
 					{
 						cache[cacheId] = command;
 					}

--- a/backend/Origam.DA.Service/AbstractSqlDataService.cs
+++ b/backend/Origam.DA.Service/AbstractSqlDataService.cs
@@ -1021,7 +1021,7 @@ namespace Origam.DA.Service
 			}
 			DataStructure dataStructure = GetDataStructure(query);
 			DataStructureFilterSet filterset = GetFilterSet(query.MethodId);
-            var cacheId 
+			var cacheId 
 				= query.DataSourceId.ToString() 
 				  + query.MethodId.ToString() 
 				  + query.SortSetId.ToString() 

--- a/backend/Origam.DA.Service/AbstractSqlDataService.cs
+++ b/backend/Origam.DA.Service/AbstractSqlDataService.cs
@@ -1020,29 +1020,33 @@ namespace Origam.DA.Service
 					.GetProfile(principal.Identity) as UserProfile;
 			}
 			DataStructure dataStructure = GetDataStructure(query);
-			var cacheId 
+            DataStructureFilterSet filterset = GetFilterSet(query.MethodId);
+            var cacheId 
 				= query.DataSourceId.ToString() 
 				  + query.MethodId.ToString() 
 				  + query.SortSetId.ToString() 
 				  + columnsInfo;
 			Hashtable cache = GetScalarCommandCache();
-			if(cache.Contains(cacheId))
+			if(cache.Contains(cacheId) && !filterset.IsDynamic)
 			{
 				command = (IDbCommand)cache[cacheId];
 				command = DbDataAdapterFactory.CloneCommand(command);
 			}
 			else
 			{
-				lock(cache)
+                command = DbDataAdapterFactory.ScalarValueCommand(
+                        dataStructure,
+                        filterset,
+                        GetSortSet(query.SortSetId),
+                        columnsInfo,
+                        query.Parameters.ToHashtable()
+                        );
+				if (!filterset.IsDynamic)
 				{
-					command = DbDataAdapterFactory.ScalarValueCommand(
-						dataStructure,
-						GetFilterSet(query.MethodId),
-						GetSortSet(query.SortSetId),
-						columnsInfo,
-						query.Parameters.ToHashtable()
-						);
-					cache[cacheId] = command;
+                    lock (cache)
+					{
+						cache[cacheId] = command;
+					}
 				}
 			}
 			IDbTransaction transaction = null;


### PR DESCRIPTION
Fix rendering sql comands for lookups with dynamic filtersets. It used to cache command queries regardless of IsDynamic settings.