### PR TITLE
FIX: Date field dropdown doesn't close after pressing Tab

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.tsx
@@ -182,7 +182,7 @@ export class DateTimeEditor extends React.Component<{
   }
 
   @action.bound handleKeyDown(event: any) {
-    if (event.key === "Escape") {
+    if (event.key === "Escape" || event.key === "Tab") {
       this.setShowFormatHint(false)
       if(this.elmDropdowner?.isDropped){
         event.closedADropdown = true;


### PR DESCRIPTION
Fixed date field dropdown not closing after pressing Tab/Shift+Tab while editing it.