### PR TITLE
UX: Remove stop cursor when hovering over readonly editor

### DIFF
--- a/frontend-html/src/gui/Components/Dropdown/Dropdown.module.scss
+++ b/frontend-html/src/gui/Components/Dropdown/Dropdown.module.scss
@@ -57,7 +57,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
       z-index: 100;
     }
     &:read-only {
-      cursor: not-allowed;
+      cursor: default;
       background: var(--background3);
       border: 1px solid var(--background3);
       color: var(--background7);

--- a/frontend-html/src/gui/Components/EditorsCommon.module.scss
+++ b/frontend-html/src/gui/Components/EditorsCommon.module.scss
@@ -46,7 +46,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
   }
 
   &:read-only {
-    cursor: not-allowed;
+    cursor: default;
     background: var(--background3);
     border: 1px solid var(--background3);
     color: var(--background7);

--- a/frontend-html/src/gui/Components/ScreenElements/Editors/BoolEditor.module.scss
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/BoolEditor.module.scss
@@ -31,4 +31,8 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
     width: 20px;
     height: 20px;
   }
+
+  &:global(.readOnly) {
+    cursor: not-allowed;
+  }
 }

--- a/frontend-html/src/gui/Components/ScreenElements/Editors/BoolEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/BoolEditor.tsx
@@ -47,9 +47,13 @@ export class BoolEditor extends React.Component<{
     }
   }
 
+  readOnly = (): string => {
+    return (this.props.isReadOnly) ? "readOnly" : "";
+  }
+
   render() {
     return (
-      <div className={cx(S.editorContainer)}>
+      <div className={cx(S.editorContainer, this.readOnly())}>
         <input
           id={this.props.id ? this.props.id : undefined}
           className="editor"


### PR DESCRIPTION
Removed the cursor stop icon when hovering over a read-only editor. The stop icon remains only in a read-only checkbox editor.