### PR TITLE
FIX: Focus lost after click and tab

### DIFF
--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorBehavior.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorBehavior.tsx
@@ -302,7 +302,7 @@ export class DropdownEditorBehavior implements IDropdownEditorBehavior {
       case "Tab":
         if (this.isDropped) {
           if (this.handlingNewValue) {
-            return;
+            break;
           }
           if (this.cursorRowId) {
             // chooseNewValue is not awaited here because we need the dropdown to close immediately and not wait for it.


### PR DESCRIPTION
clicking on dropdown item when editing a combobox value and pressing tab fast after that