### PR TITLE
FIX: Editor in table was misaligned 2024.8

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Table/Table.tsx
@@ -259,9 +259,7 @@ export class RawTable extends React.Component<ITableProps & { isVisible: boolean
   }
 
   componentDidUpdate(prevProps: ITableProps & { isVisible: boolean }) {
-    if (this.props.isVisible !== prevProps.isVisible) {
-      this.remeasureCellArea();
-    }
+    this.remeasureCellArea();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
 If the table was in a popup window. The editor was rendered 15px below its intended position