### PR TITLE
Fix code scanning alert #22: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/backend/Origam.Workflow/WorkQueue/WorkQueueIncrementalFileLoader.cs
+++ b/backend/Origam.Workflow/WorkQueue/WorkQueueIncrementalFileLoader.cs
@@ -199,8 +199,14 @@ public class WorkQueueIncrementalFileLoader : WorkQueueLoaderAdapter
                 filename, FileMode.Open))
             using(ZipArchive archive = new ZipArchive(fileStream))
             {
+                string fullDestDirPath = Path.GetFullPath(path + Path.DirectorySeparatorChar);
                 foreach(ZipArchiveEntry archiveEntry in archive.Entries)
                 {
+                    string destFileName = Path.GetFullPath(Path.Combine(path, archiveEntry.FullName));
+                    if (!destFileName.StartsWith(fullDestDirPath))
+                    {
+                        throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+                    }
                     if(FitsMask(archiveEntry.Name) 
                     && !hashIndexFile.IsZipArchiveEntryProcessed(
                         archiveEntry))

--- a/backend/Origam.Workflow/WorkQueue/WorkQueueIncrementalFileLoader.cs
+++ b/backend/Origam.Workflow/WorkQueue/WorkQueueIncrementalFileLoader.cs
@@ -199,13 +199,13 @@ public class WorkQueueIncrementalFileLoader : WorkQueueLoaderAdapter
                 filename, FileMode.Open))
             using(ZipArchive archive = new ZipArchive(fileStream))
             {
-                string fullDestDirPath = Path.GetFullPath(path + Path.DirectorySeparatorChar);
+                string fullDestinationDirPath = Path.GetFullPath(path + Path.DirectorySeparatorChar);
                 foreach(ZipArchiveEntry archiveEntry in archive.Entries)
                 {
-                    string destFileName = Path.GetFullPath(Path.Combine(path, archiveEntry.FullName));
-                    if (!destFileName.StartsWith(fullDestDirPath))
+                    string destinationFileName = Path.GetFullPath(Path.Combine(path, archiveEntry.FullName));
+                    if (!destinationFileName.StartsWith(fullDestinationDirPath))
                     {
-                        throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+                        throw new InvalidOperationException("Entry is outside the target dir: " + destinationFileName);
                     }
                     if(FitsMask(archiveEntry.Name) 
                     && !hashIndexFile.IsZipArchiveEntryProcessed(


### PR DESCRIPTION
Fixes [https://github.com/origam/origam/security/code-scanning/22](https://github.com/origam/origam/security/code-scanning/22)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
