### PR TITLE
FIX: Typo in language name in _appsettings.template for Docker

### DIFF
--- a/docker/_appsettings.template
+++ b/docker/_appsettings.template
@@ -91,7 +91,7 @@
             },
             {
                 "Culture": "cs-CZ",
-                "Caption": "Cesky",
+                "Caption": "Česky",
 				"ResetPasswordMailSubject": "Obnova Hesla",
 				"ResetPasswordMailBodyFileName": "testResetPwFile.txt",
 				"DateCompleterConfig":{


### PR DESCRIPTION
Corrected typo in Czech language name in _appsettings.template for Docker