### PR TITLE
UX: Preventing drag and drop values between inputs 2024.11

### DIFF
--- a/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/DateTimeEditor/DateTimeEditor.tsx
@@ -292,6 +292,7 @@ export class DateTimeEditor extends React.Component<{
                     onClick={this.props.onClick}
                     onDoubleClick={this.props.onDoubleClick}
                     onKeyDown={this.handleKeyDown}
+                    onDragStart={(e: any) =>  e.preventDefault()}
                   />
                 </>
               )}
@@ -348,6 +349,7 @@ export class DateTimeEditor extends React.Component<{
           onClick={this.props.onClick}
           onDoubleClick={this.props.onDoubleClick}
           onKeyDown={this.handleKeyDown}
+          onDragStart={(e: any) =>  e.preventDefault()}
         />
       </div>
     );

--- a/frontend-html/src/gui/Components/ScreenElements/Editors/NumberEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/NumberEditor.tsx
@@ -189,6 +189,7 @@ export class NumberEditor extends React.Component<NumberEditorProps, any> {
           onDoubleClick={this.props.onDoubleClick}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
+          onDragStart={(e: any) =>  e.preventDefault()}
         />
       </div>
     );

--- a/frontend-html/src/gui/Components/ScreenElements/Editors/TagInputEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/TagInputEditor.tsx
@@ -180,6 +180,7 @@ export const TagInputEditor = inject(({property}: { property: IProperty }, {valu
               autoComplete={"off"}
               style={getStyle()}
               size={1}
+              onDragStart={(e: any) =>  e.preventDefault()}
             />
           </TagInput>
         </div>

--- a/frontend-html/src/gui/Components/ScreenElements/Editors/TextEditor.tsx
+++ b/frontend-html/src/gui/Components/ScreenElements/Editors/TextEditor.tsx
@@ -242,6 +242,7 @@ export class TextEditor extends React.Component<{
           onDoubleClick={this.props.onDoubleClick}
           onBlur={this.props.onEditorBlur}
           onFocus={this.handleFocus}
+          onDragStart={(e: any) =>  e.preventDefault()}
         />
       );
     }

--- a/frontend-html/src/modules/DataView/DataViewData.ts
+++ b/frontend-html/src/modules/DataView/DataViewData.ts
@@ -34,7 +34,6 @@ export class DataViewData {
     const dataTable = this.dataTable();
     const property = this.propertyById(propertyId);
     const row = dataTable.getRowById(rowId);
-    //dataTable.resolveCellText(property, value)
     if (property && row) {
       return dataTable.getCellValue(row, property);
     } else return null;

--- a/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
+++ b/frontend-html/src/modules/Editors/DropdownEditor/DropdownEditorInput.tsx
@@ -128,6 +128,7 @@ export function DropdownEditorInput(props: {
           autoCorrect={"off"}
           autoCapitalize={"off"}
           spellCheck={"false"}
+          onDragStart={(e: any) =>  e.preventDefault()}
         />
       )}
     </Observer>


### PR DESCRIPTION
It was possible to drag and drop values between inputs on form leading to confusing/wrong results

(cherry picked from commit b40cc6e23db19efeb5a19cf71beb971a98a0bb85)