### PR TITLE
BUILD: Vulnerability warnings are not treated as errors.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,11 +93,11 @@ jobs:
     - name: Build Server
       run: |
        cd backend
-       msbuild Origam.sln -warnaserror -t:build /p:Configuration="Release Server" /t:Server\Origam_Server:Publish -v:m
+       msbuild Origam.sln -warnaserror -warnNotAsError:NU1901;NU1902;NU1903;NU1904 -t:build /p:Configuration="Release Server" /t:Server\Origam_Server:Publish -v:m
     - name: Build Origam.WorkflowTests
       run: |
        cd backend
-       msbuild Origam.sln -warnaserror -t:build /p:Configuration="Release Server" /t:Workflow\Origam_WorkflowTests:Publish -v:m
+       msbuild Origam.sln -warnaserror -warnNotAsError:NU1901;NU1902;NU1903;NU1904 -t:build /p:Configuration="Release Server" /t:Workflow\Origam_WorkflowTests:Publish -v:m
        
     - name: Upload server artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -93,11 +93,11 @@ jobs:
     - name: Build Server
       run: |
        cd backend
-       msbuild Origam.sln -warnaserror -warnNotAsError:NU1901;NU1902;NU1903;NU1904 -t:build /p:Configuration="Release Server" /t:Server\Origam_Server:Publish -v:m
+       msbuild Origam.sln -warnaserror -warnNotAsError:NU1901,NU1902,NU1903,NU1904 -t:build /p:Configuration="Release Server" /t:Server\Origam_Server:Publish -v:m
     - name: Build Origam.WorkflowTests
       run: |
        cd backend
-       msbuild Origam.sln -warnaserror -warnNotAsError:NU1901;NU1902;NU1903;NU1904 -t:build /p:Configuration="Release Server" /t:Workflow\Origam_WorkflowTests:Publish -v:m
+       msbuild Origam.sln -warnaserror -warnNotAsError:NU1901,NU1902,NU1903,NU1904 -t:build /p:Configuration="Release Server" /t:Workflow\Origam_WorkflowTests:Publish -v:m
        
     - name: Upload server artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Host machine got updated and it suddenly started to report package vulnerabilities. Some of the vulnerabilities are not in direct references and they're difficult to solved. So vulnerability warnings are not going be treated as errors.

https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/dotnet-restore-audit