### PR TITLE
FIX: Notification context store wasn't aligned with the model

### DIFF
--- a/backend/Origam.Workflow/WorkQueue/WorkQueueService.cs
+++ b/backend/Origam.Workflow/WorkQueue/WorkQueueService.cs
@@ -496,7 +496,7 @@ public class WorkQueueService : IWorkQueueService, IBackgroundService
             // anything else - we execute the workflow in order to get the addresses
             QueryParameterCollection pms = new QueryParameterCollection();
             pms.Add(new QueryParameter("workQueueNotificationContactTypeId", workQueueNotificationContactTypeId));
-            pms.Add(new QueryParameter("origamNotificationChannelTypeId", origamNotificationChannelTypeId));
+            pms.Add(new QueryParameter("OrigamNotificationChannelTypeId", origamNotificationChannelTypeId));
             pms.Add(new QueryParameter("value", value));
             pms.Add(new QueryParameter("context", context));
             if (workQueueRow != null)


### PR DESCRIPTION
https://community.origam.com/t/error-while-calling-getnotificationcontacts-from-workqueueservice-contextstore-not-found/3897