### PR TITLE
FIX: Work queue workflow loader DataDocumentCore result not supported

### DIFF
--- a/backend/Origam.Workflow/WorkQueue/WorkQueueWorkflowLoader.cs
+++ b/backend/Origam.Workflow/WorkQueue/WorkQueueWorkflowLoader.cs
@@ -29,13 +29,12 @@ using Origam.Schema;
 using Origam.Workbench.Services;
 using Origam.Schema.WorkflowModel;
 using Origam.Service.Core;
-using core=Origam.Workbench.Services.CoreServices;
 
 namespace Origam.Workflow.WorkQueue;
 /// <summary>
 /// Connection string:
-/// name - name of the workflowLoader defined at the WorkQueueClass. The worklow called must implement
-///		   IWorkQueueLoder workflow defined in the OrigamRoot model.
+/// name - name of the workflowLoader defined at the WorkQueueClass.
+/// The workflow called must implement IWorkQueueLoader workflow defined in the OrigamRoot model.
 /// anything else - input workflow parameters - constant text values as defined in the connection string
 /// </summary>
 public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
@@ -156,7 +155,7 @@ public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
 			}
 			throw workflowEngine.WorkflowException;
 		}
-		XmlContainer resultData = workflowEngine.ReturnValue as XmlContainer;
+		var resultData = workflowEngine.ReturnValue as IXmlContainer;
 		_resultState = (string)workflowEngine.RuleEngine.GetContext(new ModelElementKey(new Guid("f405cef2-2fad-4d58-a71c-10df3831e966")));
 		_attachmentSource = (IDataDocument)workflowEngine.RuleEngine.GetContext((new ModelElementKey(new Guid("b0caa6ec-8a54-4524-8387-8504e34d206c"))));
 		if(log.IsDebugEnabled)
@@ -170,7 +169,7 @@ public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
 			{
 				log.Debug("Workflow loader result was null.");
 			}
-			throw new Exception("Result of work queue loader must be an XMLContainer.");
+			throw new Exception("Result of work queue loader must be an IXmlContainer.");
 		}
 		else if(resultData.Xml.DocumentElement == null)
 		{

--- a/backend/Origam.Workflow/WorkQueue/WorkQueueWorkflowLoader.cs
+++ b/backend/Origam.Workflow/WorkQueue/WorkQueueWorkflowLoader.cs
@@ -24,6 +24,7 @@ using System.Collections;
 using System.Xml;
 using System.Xml.XPath;
 using System.Data;
+using log4net;
 using Origam.Extensions;
 using Origam.Schema;
 using Origam.Workbench.Services;
@@ -39,30 +40,38 @@ namespace Origam.Workflow.WorkQueue;
 /// </summary>
 public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
 {
-	private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
-	Hashtable _inputParameters = new Hashtable();
-	IWorkflow _workflow;
-	bool _executed = false;
-	string _resultState;
-    IDataDocument _attachmentSource;
-	WorkQueueClass _wqc;
-	XPathNodeIterator _resultIterator;
-	public WorkQueueWorkflowLoader()
+	private static readonly ILog log = LogManager.GetLogger(
+		System.Reflection.MethodBase.GetCurrentMethod()?.DeclaringType);
+
+	private readonly Hashtable inputParameters = new();
+	private IWorkflow workflow;
+	private bool executed = false;
+	private string resultState;
+    private IDataDocument attachmentSource;
+	private WorkQueueClass workQueueClass;
+	private XPathNodeIterator resultIterator;
+	
+	public override void Connect(
+		IWorkQueueService service, 
+		Guid queueId, 
+		string workQueueClass, 
+		string connection, 
+		string userName, 
+		string password, 
+		string transactionId)
 	{
-	}
-	public override void Connect(IWorkQueueService service, Guid queueId, string workQueueClass, string connection, string userName, string password, string transactionId)
-	{
-		if(log.IsInfoEnabled)
+		if (log.IsInfoEnabled)
 		{
 			log.Info("Connecting " + connection);
 		}
-		_inputParameters.Add("userName", userName);
-		_inputParameters.Add("password", password);
+		inputParameters.Add("userName", userName);
+		inputParameters.Add("password", password);
 		string name = null;
-		string[] cnParts = connection.Split(";".ToCharArray());
-		foreach (string part in cnParts)
+		string[] connectionStringParts 
+			= connection.Split(";".ToCharArray());
+		foreach (string connectionStringPart in connectionStringParts)
 		{
-			string[] pair = part.Split("=".ToCharArray());
+			string[] pair = connectionStringPart.Split("=".ToCharArray());
 			if (pair.Length == 2)
 			{
 				switch (pair[0])
@@ -71,27 +80,27 @@ public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
 						name = pair[1];
 						break;
 					default:
-						_inputParameters[pair[0]] = pair[1];
+						inputParameters[pair[0]] = pair[1];
 						break;
 				}
 			}
 		}
-		_wqc = service.WQClass(queueId) as WorkQueueClass;
-		WorkqueueLoader loader = _wqc.GetLoader(name);
-		_workflow = loader.Workflow;
+		this.workQueueClass = service.WQClass(queueId) as WorkQueueClass;
+		WorkqueueLoader loader = this.workQueueClass?.GetLoader(name);
+		workflow = loader?.Workflow;
 	}
 	public override void Disconnect()
 	{
-		_inputParameters.Clear();
-		_workflow = null;
+		inputParameters.Clear();
+		workflow = null;
 	}
 	public override WorkQueueAdapterResult GetItem(string lastState)
 	{
-		if(!_executed)
+		if (!executed)
 		{
-			if(LoadData(lastState))
+			if (LoadData(lastState))
 			{
-				_executed = true;
+				executed = true;
 			}
 			else
 			{
@@ -99,93 +108,108 @@ public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
 				return null;
 			}
 		}
-		DataTable attachmentTable = _attachmentSource.DataSet.Tables["Attachment"];
-		if(_resultIterator.Count > 1 && attachmentTable.Rows.Count > 0)
+		DataTable attachmentTable 
+			= attachmentSource.DataSet.Tables["Attachment"];
+		if ((resultIterator.Count > 1) && (attachmentTable.Rows.Count > 0))
 		{
-			throw new Exception("Workflow returned multiple results and attachments. Returning attachments is not supported when returning multiple results by a workflow to the work queue.");
+			throw new Exception(
+				"Workflow returned multiple results and attachments. Returning attachments is not supported when returning multiple results by a workflow to the work queue.");
 		}
-		if (_resultIterator.MoveNext())
-		{
-			if(_resultIterator.CurrentPosition > _resultIterator.Count) return null;
-		    IXmlContainer document = DataDocumentFactory.New(XmlTools.GetXmlSlice(_resultIterator));
-			WorkQueueAdapterResult result = new WorkQueueAdapterResult(document);
-			result.State = _resultState;
-			result.Attachments = new WorkQueueAttachment[attachmentTable.Rows.Count];
-			if(log.IsDebugEnabled)
-			{
-				log.Debug("Workflow loader returned " + attachmentTable.Rows.Count.ToString() + " attachments.");
-				log.Debug(document.Xml.OuterXml);
-			}
-			for(int i=0; i<attachmentTable.Rows.Count; i++)
-			{
-				result.Attachments[i] = new WorkQueueAttachment();
-				result.Attachments[i].Name = (string)attachmentTable.Rows[i]["FileName"];
-				result.Attachments[i].Data = (byte[])attachmentTable.Rows[i]["Data"];
-			}
-		
-			return result;
-		}
-		else
+		if (!resultIterator.MoveNext())
 		{
 			return null;
 		}
+		if (resultIterator.CurrentPosition > resultIterator.Count)
+		{
+			return null;
+		}
+		IXmlContainer document = DataDocumentFactory.New(
+			XmlTools.GetXmlSlice(resultIterator));
+		var result = new WorkQueueAdapterResult(document)
+		{
+			State = resultState,
+			Attachments = new WorkQueueAttachment[attachmentTable.Rows.Count]
+		};
+		if (log.IsDebugEnabled)
+		{
+			log.Debug(
+				$"Workflow loader returned {attachmentTable.Rows.Count} attachments.");
+			log.Debug(document.Xml.OuterXml);
+		}
+		for (int i=0; i<attachmentTable.Rows.Count; i++)
+		{
+			result.Attachments[i] = new WorkQueueAttachment
+			{
+				Name = (string)attachmentTable.Rows[i]["FileName"],
+				Data = (byte[])attachmentTable.Rows[i]["Data"]
+			};
+		}
+		return result;
 	}
 	private bool LoadData(string lastState)
 	{
-		_inputParameters["lastState"] = lastState;
+		inputParameters["lastState"] = lastState;
 		WorkflowHost host = WorkflowHost.DefaultHost;
-		WorkflowEngine workflowEngine = WorkflowEngine.PrepareWorkflow(_workflow, _inputParameters, false, _workflow.Name);
-		
-		if(log.IsDebugEnabled)
+		WorkflowEngine workflowEngine = WorkflowEngine.PrepareWorkflow(
+			workflow, 
+			inputParameters, 
+			isRepeatable: false, 
+			workflow.Name);
+		if (log.IsDebugEnabled)
 		{
-			log.Debug("Starting workflow " + _workflow.Name);
+			log.Debug("Starting workflow " + workflow.Name);
 		}
-		// execute workflow
 		host.ExecuteWorkflow(workflowEngine);
-		if(log.IsDebugEnabled)
+		if (log.IsDebugEnabled)
 		{
-			log.Debug("Finishing workflow " + _workflow.Name);
+			log.Debug("Finishing workflow " + workflow.Name);
 		}
-		// handle exception
-		if(workflowEngine.WorkflowException != null)
+		if (workflowEngine.WorkflowException != null)
 		{
-			if(log.IsErrorEnabled)
+			if (log.IsErrorEnabled)
 			{
-				log.LogOrigamError(workflowEngine.WorkflowException.Message, workflowEngine.WorkflowException);
+				log.LogOrigamError(
+					workflowEngine.WorkflowException.Message, 
+					workflowEngine.WorkflowException);
 			}
 			throw workflowEngine.WorkflowException;
 		}
 		var resultData = workflowEngine.ReturnValue as IXmlContainer;
-		_resultState = (string)workflowEngine.RuleEngine.GetContext(new ModelElementKey(new Guid("f405cef2-2fad-4d58-a71c-10df3831e966")));
-		_attachmentSource = (IDataDocument)workflowEngine.RuleEngine.GetContext((new ModelElementKey(new Guid("b0caa6ec-8a54-4524-8387-8504e34d206c"))));
-		if(log.IsDebugEnabled)
+		resultState = (string)workflowEngine.RuleEngine.GetContext(
+			new ModelElementKey(
+				new Guid("f405cef2-2fad-4d58-a71c-10df3831e966")));
+		attachmentSource = (IDataDocument)workflowEngine.RuleEngine.GetContext(
+			new ModelElementKey(
+				new Guid("b0caa6ec-8a54-4524-8387-8504e34d206c")));
+		if (log.IsDebugEnabled)
 		{
 			log.Debug("Workflow loader result:");
 			log.Debug(resultData?.Xml.OuterXml);
 		}
-		if(resultData == null)
+		if (resultData == null)
 		{
-			if(log.IsDebugEnabled)
+			if (log.IsDebugEnabled)
 			{
 				log.Debug("Workflow loader result was null.");
 			}
-			throw new Exception("Result of work queue loader must be an IXmlContainer.");
+			throw new Exception(
+				"Result of work queue loader must be an IXmlContainer.");
 		}
-		else if(resultData.Xml.DocumentElement == null)
+		if (resultData.Xml.DocumentElement == null)
 		{
-			if(log.IsDebugEnabled)
+			if (log.IsDebugEnabled)
 			{
 				log.Debug("Workflow loader result was an empty XML Document.");
 			}
 			return false;
 		}
 		string xpath = "/";
-		if(_wqc.Entity == null)
+		if (workQueueClass.Entity == null)
 		{
 			XmlNode firstChild = resultData.Xml.FirstChild;
 			XmlNode secondChild = firstChild.FirstChild;
 			xpath += firstChild.Name;
-			if(secondChild != null)
+			if (secondChild != null)
 			{
 				xpath += "/" + secondChild.Name;
 			}
@@ -198,10 +222,10 @@ public class WorkQueueWorkflowLoader : WorkQueueLoaderAdapter
 		}
 		else
 		{
-			xpath = "/ROOT/" + _wqc.Entity.Name;
+			xpath = "/ROOT/" + workQueueClass.Entity.Name;
 		}
-		XPathNavigator nav = resultData.Xml.CreateNavigator();
-		_resultIterator = nav.Select(xpath);
+		XPathNavigator navigator = resultData.Xml.CreateNavigator();
+		resultIterator = navigator?.Select(xpath);
 		return true;
 	}
 }


### PR DESCRIPTION
Workflow loader accepted only results of `XmlContainer` type, preventing `DataDocumentCore`. Now the result is expected to be of `IXmlContainer` type, thus accepting both `XmlContainer` and `DataDocumentCore`.