### PR TITLE
FIX: Server cleans up valid tokens during bootup

### DIFF
--- a/model-root/model/Security/.origamPackage
+++ b/model-root/model/Security/.origamPackage
@@ -8,7 +8,7 @@
     x:id="951f2cda-2867-4b99-8824-071fa8749ead"
     x:isFolder="true"
     p:name="Security"
-    p:version="5.4.3">
+    p:version="5.4.4">
     <pr:packageReference
       x:id="6b99e793-23bb-47fb-873e-2962679bd9d2"
       pr:referencedPackage="Root/.origamPackage#147fa70d-6519-4393-b5d0-87931f9fd609" />

--- a/model-root/model/Security/DeploymentVersion/Security/5.4.4.origam
+++ b/model-root/model/Security/DeploymentVersion/Security/5.4.4.origam
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<x:file
+  xmlns:x="http://schemas.origam.com/model-persistence/1.0.0"
+  xmlns:asi="http://schemas.origam.com/Origam.Schema.AbstractSchemaItem/6.0.0"
+  xmlns:ausa="http://schemas.origam.com/Origam.Schema.DeploymentModel.AbstractUpdateScriptActivity/6.0.0"
+  xmlns:dv="http://schemas.origam.com/Origam.Schema.DeploymentModel.DeploymentVersion/6.0.0"
+  xmlns:scusa="http://schemas.origam.com/Origam.Schema.DeploymentModel.ServiceCommandUpdateScriptActivity/6.0.0">
+  <dv:DeploymentVersion
+    asi:abstract="false"
+    dv:deploymentDependenciesCsv="&#xD;&#xA;147fa70d-6519-4393-b5d0-87931f9fd609, 5.3.3"
+    x:id="e50e7011-d283-4205-80ac-2b4f020159e3"
+    asi:name="5.4.4"
+    dv:version="5.4.4">
+    <scusa:DeploymentUpdateScriptActivity
+      asi:abstract="false"
+      ausa:activityOrder="20"
+      scusa:commandText="-***-ExternalFile:5.4.4.origam___commandText___bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a.txt"
+      x:id="bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a"
+      asi:name="00020_PG_Alter_Procedure_OrigamIdentityGrantCleanUp"
+      scusa:platform="PgSql"
+      scusa:service="Root/Service/DataService.origam#DataService/bbd7bd32-d40b-441a-bb5b-0b0fa89169d4" />
+    <scusa:DeploymentUpdateScriptActivity
+      asi:abstract="false"
+      ausa:activityOrder="10"
+      scusa:commandText="-***-ExternalFile:5.4.4.origam___commandText___e4a3c394-5c9b-467c-b13e-4a226c035843.txt"
+      x:id="e4a3c394-5c9b-467c-b13e-4a226c035843"
+      asi:name="00010_Alter_Procedure_OrigamIdentityGrantCleanUp"
+      scusa:platform="MsSql"
+      scusa:service="Root/Service/DataService.origam#DataService/bbd7bd32-d40b-441a-bb5b-0b0fa89169d4" />
+  </dv:DeploymentVersion>
+</x:file>

--- a/model-root/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a.txt
+++ b/model-root/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a.txt
@@ -1,0 +1,16 @@
+﻿DROP PROCEDURE IF EXISTS "OrigamIdentityGrantCleanup";
+
+CREATE PROCEDURE "OrigamIdentityGrantCleanup"()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    current_datetime TIMESTAMP := AT TIME ZONE 'UTC';
+BEGIN
+    LOOP
+        DELETE FROM "OrigamIdentityGrant"
+        WHERE "Expiration" < current_datetime
+        LIMIT 1000;
+        EXIT WHEN NOT FOUND;
+    END LOOP;
+END;
+$$;

--- a/model-root/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___e4a3c394-5c9b-467c-b13e-4a226c035843.txt
+++ b/model-root/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___e4a3c394-5c9b-467c-b13e-4a226c035843.txt
@@ -1,0 +1,12 @@
+﻿ALTER   PROCEDURE [dbo].[OrigamIdentityGrantCleanup]
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @CurrentDateTime AS datetime2 = GETUTCDATE();
+    WHILE (@@ROWCOUNT > 0)
+    BEGIN
+        DELETE TOP (1000)
+        FROM OrigamIdentityGrant
+        WHERE Expiration < @CurrentDateTime;
+    END
+END

--- a/model-tests/model/Security/.origamPackage
+++ b/model-tests/model/Security/.origamPackage
@@ -8,7 +8,7 @@
     x:id="951f2cda-2867-4b99-8824-071fa8749ead"
     x:isFolder="true"
     p:name="Security"
-    p:version="5.4.3">
+    p:version="5.4.4">
     <pr:packageReference
       x:id="6b99e793-23bb-47fb-873e-2962679bd9d2"
       pr:referencedPackage="Root/.origamPackage#147fa70d-6519-4393-b5d0-87931f9fd609" />

--- a/model-tests/model/Security/DeploymentVersion/Security/5.4.1.origam
+++ b/model-tests/model/Security/DeploymentVersion/Security/5.4.1.origam
@@ -37,10 +37,10 @@
       scusa:service="Root/Service/DataService.origam#DataService/bbd7bd32-d40b-441a-bb5b-0b0fa89169d4" />
     <scusa:DeploymentUpdateScriptActivity
       asi:abstract="false"
-      ausa:activityOrder="30"
+      ausa:activityOrder="40"
       scusa:commandText="-***-ExternalFile:5.4.1.origam___commandText___651414c9-af75-473a-82be-4cf3e009fa4e.txt"
       x:id="651414c9-af75-473a-82be-4cf3e009fa4e"
-      asi:name="00030_PG_Database_Entity_OrigamIdentityGrant"
+      asi:name="00040_PG_Database_Entity_OrigamIdentityGrant"
       scusa:platform="PgSql"
       scusa:service="Root/Service/DataService.origam#DataService/bbd7bd32-d40b-441a-bb5b-0b0fa89169d4" />
   </dv:DeploymentVersion>

--- a/model-tests/model/Security/DeploymentVersion/Security/5.4.4.origam
+++ b/model-tests/model/Security/DeploymentVersion/Security/5.4.4.origam
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<x:file
+  xmlns:x="http://schemas.origam.com/model-persistence/1.0.0"
+  xmlns:asi="http://schemas.origam.com/Origam.Schema.AbstractSchemaItem/6.0.0"
+  xmlns:ausa="http://schemas.origam.com/Origam.Schema.DeploymentModel.AbstractUpdateScriptActivity/6.0.0"
+  xmlns:dv="http://schemas.origam.com/Origam.Schema.DeploymentModel.DeploymentVersion/6.0.0"
+  xmlns:scusa="http://schemas.origam.com/Origam.Schema.DeploymentModel.ServiceCommandUpdateScriptActivity/6.0.0">
+  <dv:DeploymentVersion
+    asi:abstract="false"
+    dv:deploymentDependenciesCsv="&#xD;&#xA;147fa70d-6519-4393-b5d0-87931f9fd609, 5.3.3"
+    x:id="e50e7011-d283-4205-80ac-2b4f020159e3"
+    asi:name="5.4.4"
+    dv:version="5.4.4">
+    <scusa:DeploymentUpdateScriptActivity
+      asi:abstract="false"
+      ausa:activityOrder="20"
+      scusa:commandText="-***-ExternalFile:5.4.4.origam___commandText___bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a.txt"
+      x:id="bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a"
+      asi:name="00020_PG_Alter_Procedure_OrigamIdentityGrantCleanUp"
+      scusa:platform="PgSql"
+      scusa:service="Root/Service/DataService.origam#DataService/bbd7bd32-d40b-441a-bb5b-0b0fa89169d4" />
+    <scusa:DeploymentUpdateScriptActivity
+      asi:abstract="false"
+      ausa:activityOrder="10"
+      scusa:commandText="-***-ExternalFile:5.4.4.origam___commandText___e4a3c394-5c9b-467c-b13e-4a226c035843.txt"
+      x:id="e4a3c394-5c9b-467c-b13e-4a226c035843"
+      asi:name="00010_Alter_Procedure_OrigamIdentityGrantCleanUp"
+      scusa:platform="MsSql"
+      scusa:service="Root/Service/DataService.origam#DataService/bbd7bd32-d40b-441a-bb5b-0b0fa89169d4" />
+  </dv:DeploymentVersion>
+</x:file>

--- a/model-tests/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a.txt
+++ b/model-tests/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___bbf3b60d-e7ad-4630-a59f-d1f297c1ff4a.txt
@@ -1,0 +1,16 @@
+﻿DROP PROCEDURE IF EXISTS "OrigamIdentityGrantCleanup";
+
+CREATE PROCEDURE "OrigamIdentityGrantCleanup"()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    current_datetime TIMESTAMP := AT TIME ZONE 'UTC';
+BEGIN
+    LOOP
+        DELETE FROM "OrigamIdentityGrant"
+        WHERE "Expiration" < current_datetime
+        LIMIT 1000;
+        EXIT WHEN NOT FOUND;
+    END LOOP;
+END;
+$$;

--- a/model-tests/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___e4a3c394-5c9b-467c-b13e-4a226c035843.txt
+++ b/model-tests/model/Security/DeploymentVersion/Security/5.4.4.origam___commandText___e4a3c394-5c9b-467c-b13e-4a226c035843.txt
@@ -1,0 +1,12 @@
+﻿ALTER   PROCEDURE [dbo].[OrigamIdentityGrantCleanup]
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DECLARE @CurrentDateTime AS datetime2 = GETUTCDATE();
+    WHILE (@@ROWCOUNT > 0)
+    BEGIN
+        DELETE TOP (1000)
+        FROM OrigamIdentityGrant
+        WHERE Expiration < @CurrentDateTime;
+    END
+END


### PR DESCRIPTION
Expiration date is stored in UTC, clean up store procedure updated so it uses UTC now.