### PR TITLE
Introduce TableMapping and upgrade scripts

### DIFF
--- a/backend/Origam.DA.Service-net2Tests/InstanceWriterTests.cs
+++ b/backend/Origam.DA.Service-net2Tests/InstanceWriterTests.cs
@@ -33,7 +33,7 @@ public class InstanceWriterTests
     [Test]
     public void ShouldWriteFile()
     {
-        var itemToWrite = new TableMappingItem();
+        var itemToWrite = new TableMapping();
         itemToWrite.Name = "TestName";
         itemToWrite.PersistenceProvider = new NullPersistenceProvider();
         OrigamXmlDocument document = new OrigamXmlDocument();

--- a/backend/Origam.DA.Service-net2Tests/MetaModelUpgraderTests/MetaModelUpgraderTests.cs
+++ b/backend/Origam.DA.Service-net2Tests/MetaModelUpgraderTests/MetaModelUpgraderTests.cs
@@ -263,4 +263,17 @@ public class MetaModelUpgraderTests: ClassUpgradeTestBase
             sut.TryUpgrade(xFileData);
         });
     }
+
+    [Test]
+    public void ShouldUpgradeTableMappingItem()
+    {
+        XFileData xFileData = LoadFile("TableMappingItemV6.0.0.origam");
+        var sut = new MetaModelAnalyzer(new NullFileWriter(), new MetaModelUpgrader(GetType().Assembly));
+        sut.TryUpgrade(xFileData);
+
+        XNamespace newNs = "http://schemas.origam.com/Origam.Schema.EntityModel.TableMapping/6.1.0";
+        XElement classNode = xFileData.Document.ClassNodes.First();
+        Assert.That(classNode.Name.Namespace, Is.EqualTo(newNs));
+        Assert.That(classNode.Name.LocalName, Is.EqualTo("DataEntity"));
+    }
 }

--- a/backend/Origam.DA.Service-net2Tests/MetaModelUpgraderTests/TestFiles/TableMappingItemV6.0.0.origam
+++ b/backend/Origam.DA.Service-net2Tests/MetaModelUpgraderTests/TestFiles/TableMappingItemV6.0.0.origam
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<x:file xmlns:x="http://schemas.origam.com/model-persistence/1.0.0" xmlns:tmi="http://schemas.origam.com/Origam.Schema.EntityModel.TableMappingItem/6.0.0">
+  <tmi:DataEntity tmi:mappedObjectName="TestTable" x:id="00000000-0000-0000-0000-000000000000" />
+</x:file>

--- a/backend/Origam.DA.Service/AbstractDataService.cs
+++ b/backend/Origam.DA.Service/AbstractDataService.cs
@@ -285,10 +285,10 @@ public abstract class AbstractDataService : IDataService
 		}
 		return result;
 	}
-	internal TableMappingItem GetTable(Guid id)
+	internal TableMapping GetTable(Guid id)
 	{
-		TableMappingItem result = this.PersistenceProvider.RetrieveInstance(typeof(TableMappingItem), 
-            new ModelElementKey(id)) as TableMappingItem;
+		TableMapping result = this.PersistenceProvider.RetrieveInstance(typeof(TableMapping), 
+            new ModelElementKey(id)) as TableMapping;
 		if(result == null)
 		{
 			throw new ArgumentException(ResourceUtils.GetString("TableMappingNotInModel", id.ToString()));

--- a/backend/Origam.DA.Service/AbstractSqlDataService.cs
+++ b/backend/Origam.DA.Service/AbstractSqlDataService.cs
@@ -170,7 +170,7 @@ internal class DataLoader
 		}
 		var standardMessage = ResourceUtils.GetString(
 			"ErrorLoadingData",
-			(Entity.EntityDefinition as TableMappingItem)?.MappedObjectName,
+			(Entity.EntityDefinition as TableMapping)?.MappedObjectName,
 			Entity.Name,
 			Environment.NewLine, exception.Message);
 		DataService.HandleException(exception, standardMessage, null);
@@ -441,7 +441,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 		{
 			return false;
 		}
-		if(!(rootEntity.Entity is TableMappingItem mappingItem))
+		if(!(rootEntity.Entity is TableMapping mappingItem))
 		{
 			return false;
 		} 
@@ -535,7 +535,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 					// in the dataset but that does not matter
 					// because we save such an entity once anyway.
 					if(!(entity.EntityDefinition 
-						   is TableMappingItem tableMapping) 
+						   is TableMapping tableMapping) 
 					   || !changedDataset.Tables.Contains(currentEntityName))
 					{
 						continue;
@@ -1291,7 +1291,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 		IDbConnection connection = transaction.Connection;
 		try
 		{
-			TableMappingItem table = GetTable(entityId);
+			TableMapping table = GetTable(entityId);
 			if(table.DatabaseObjectType != DatabaseMappingObjectType.Table)
 			{
 				throw new ArgumentOutOfRangeException(
@@ -1379,7 +1379,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 		IDbConnection connection = transaction.Connection;
 		try
 		{
-			TableMappingItem table = GetTable(entityId);
+			TableMapping table = GetTable(entityId);
 			if(table.DatabaseObjectType != DatabaseMappingObjectType.Table)
 			{
 				throw new ArgumentOutOfRangeException(
@@ -1621,8 +1621,8 @@ public abstract class AbstractSqlDataService : AbstractDataService
 	
     public override string EntityDdl(Guid entityId)
     {
-        if(!(PersistenceProvider.RetrieveInstance(typeof(TableMappingItem), 
-	            new ModelElementKey(entityId)) is TableMappingItem table))
+        if(!(PersistenceProvider.RetrieveInstance(typeof(TableMapping), 
+	            new ModelElementKey(entityId)) is TableMapping table))
         {
             throw new ArgumentOutOfRangeException("entityId", entityId, 
                 "Element is not a table mapping.");
@@ -1640,7 +1640,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
         }
         result[0] = DbDataAdapterFactory.AddColumnDdl(column);
         result[1] = DbDataAdapterFactory.AddForeignKeyConstraintDdl(
-            column.ParentItem as TableMappingItem, 
+            column.ParentItem as TableMapping, 
             column.ForeignKeyConstraint);
         return result;
     }
@@ -1937,7 +1937,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 	public override List<SchemaDbCompareResult> CompareSchema(IPersistenceProvider provider)
 	{
 		var results = new List<SchemaDbCompareResult>();
-		List<TableMappingItem> schemaTables = GetSchemaTables(provider);
+		List<TableMapping> schemaTables = GetSchemaTables(provider);
         // tables
         Hashtable schemaTableList = GetSchemaTableList(schemaTables);
 		var schemaColumnList = new Hashtable();
@@ -1947,10 +1947,10 @@ public abstract class AbstractSqlDataService : AbstractDataService
 		columns.CaseSensitive = true;
 		DoCompare(results, dbTableList, schemaTableList, columns, 
 			DbCompareResultType.MissingInDatabase, 
-			typeof(TableMappingItem), provider);
+			typeof(TableMapping), provider);
 		DoCompare(results, dbTableList, schemaTableList, columns, 
 			DbCompareResultType.MissingInSchema, 
-			typeof(TableMappingItem), provider);
+			typeof(TableMapping), provider);
         // fields
         // model exists in database
         DoCompareModelInDatabase(results, schemaTables, 
@@ -1986,10 +1986,10 @@ public abstract class AbstractSqlDataService : AbstractDataService
 		return results;
 	}
     private void DoCompareIndexExistingTables(
-        List<SchemaDbCompareResult> results, List<TableMappingItem> schemaTables, DataSet foreignKeys, 
+        List<SchemaDbCompareResult> results, List<TableMapping> schemaTables, DataSet foreignKeys, 
         DataSet columns)
     {
-        foreach(TableMappingItem table in schemaTables)
+        foreach(TableMapping table in schemaTables)
         {
             // not for views and not for tables where generating script
             // is turned off
@@ -2010,10 +2010,10 @@ public abstract class AbstractSqlDataService : AbstractDataService
 	                bool found = table.Constraints
 		                .Where(constraint => 
 			                (constraint.Type == ConstraintType.ForeignKey) 
-			                && (constraint.ForeignEntity is TableMappingItem))
+			                && (constraint.ForeignEntity is TableMapping))
 		                .Any(constraint => 
 			                ((string)row["PK_Table"] 
-			                == ((TableMappingItem)constraint.ForeignEntity)
+			                == ((TableMapping)constraint.ForeignEntity)
 								.MappedObjectName) 
 			                && ((string)row["FK_Table"] 
 			                    == table.MappedObjectName));
@@ -2042,18 +2042,18 @@ public abstract class AbstractSqlDataService : AbstractDataService
         }
     }
     private void CompareConstraintMissingInDatabase(
-        DataEntityConstraint constraint, TableMappingItem table,
+        DataEntityConstraint constraint, TableMapping table,
         DataSet foreignKeys, DataSet columns, List<SchemaDbCompareResult> results)
     {
 		if((constraint.Type != ConstraintType.ForeignKey) 
-		   || !(constraint.ForeignEntity is TableMappingItem) 
+		   || !(constraint.ForeignEntity is TableMapping) 
 		   || !(constraint.Fields[0] is FieldMappingItem))
 		{
 			return;
 		}
 		DataRow[] rows = foreignKeys.Tables[0].Select(
 			"PK_Table = '" 
-			+ (constraint.ForeignEntity as TableMappingItem)
+			+ (constraint.ForeignEntity as TableMapping)
 			.MappedObjectName 
 			+ "' AND FK_Table = '" 
 			+ table.MappedObjectName 
@@ -2140,7 +2140,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 								   .MappedColumnName 
 							   + "_" 
 							   + (constraint.ForeignEntity 
-								   as TableMappingItem).MappedObjectName,
+								   as TableMapping).MappedObjectName,
 					SchemaItem = table,
 					SchemaItemType = typeof(
 						DataEntityConstraint)
@@ -2151,9 +2151,9 @@ public abstract class AbstractSqlDataService : AbstractDataService
     }
     internal abstract string GetSqlFk();
     private void DoCompareIndex(
-        List<SchemaDbCompareResult> results, List<TableMappingItem> schemaTables, DataSet indexFields)
+        List<SchemaDbCompareResult> results, List<TableMapping> schemaTables, DataSet indexFields)
     {
-        foreach(TableMappingItem table in schemaTables)
+        foreach(TableMapping table in schemaTables)
         {
             if(!table.GenerateDeploymentScript 
                || (table.DatabaseObjectType 
@@ -2239,7 +2239,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
     internal abstract Hashtable GetDbIndexList(
         DataSet indexes, Hashtable schemaTableList);
     internal abstract Hashtable GetSchemaIndexListGenerate(
-	    List<TableMappingItem> schemaTables, Hashtable dbTableList, 
+	    List<TableMapping> schemaTables, Hashtable dbTableList, 
         Hashtable schemaIndexListAll);
     
     internal abstract string GetSqlIndexFields();
@@ -2369,10 +2369,10 @@ public abstract class AbstractSqlDataService : AbstractDataService
 		return stringBuilder.ToString().ToUpper();
 	}
     private void DoCompareModelInDatabase(
-        List<SchemaDbCompareResult> results, List<TableMappingItem> schemaTables, Hashtable dbTableList, 
+        List<SchemaDbCompareResult> results, List<TableMapping> schemaTables, Hashtable dbTableList, 
         Hashtable schemaColumnList, DataSet columns)
     {
-        foreach(TableMappingItem table in schemaTables)
+        foreach(TableMapping table in schemaTables)
         {
             // only if the table exists in the database,
             // otherwise we will be creating the whole table later on
@@ -2459,10 +2459,10 @@ public abstract class AbstractSqlDataService : AbstractDataService
         return dbTableList;
     }
     
-    private Hashtable GetSchemaTableList(List<TableMappingItem> schemaTables)
+    private Hashtable GetSchemaTableList(List<TableMapping> schemaTables)
     {
         var schemaTableList = new Hashtable();
-        foreach(TableMappingItem table in schemaTables)
+        foreach(TableMapping table in schemaTables)
         {
             if(!schemaTableList.Contains(table.MappedObjectName))
             {
@@ -2471,20 +2471,20 @@ public abstract class AbstractSqlDataService : AbstractDataService
         }
         return schemaTableList;
     }
-    private List<TableMappingItem> GetSchemaTables(IPersistenceProvider provider)
+    private List<TableMapping> GetSchemaTables(IPersistenceProvider provider)
     {
         List<ISchemaItem> entityList = provider
             .RetrieveListByCategory<ISchemaItem>(
 	            AbstractDataEntity.CategoryConst);
-        var schemaTables = new List<TableMappingItem>();
+        var schemaTables = new List<TableMapping>();
         foreach(var tableMappingItem 
-                in entityList.OfType<TableMappingItem>())
+                in entityList.OfType<TableMapping>())
         {
             schemaTables.Add(tableMappingItem);
         }
         return schemaTables;
     }
-    private static string ConstraintName(TableMappingItem table, 
+    private static string ConstraintName(TableMapping table, 
         DataEntityConstraint constraint)
     {
         return 
@@ -2493,7 +2493,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
             + "_" 
             + ((FieldMappingItem)constraint.Fields[0]).MappedColumnName 
             + "_" 
-            + ((TableMappingItem)constraint.ForeignEntity).MappedObjectName;
+            + ((TableMapping)constraint.ForeignEntity).MappedObjectName;
     }
 	private void DoCompare(List<SchemaDbCompareResult> results, Hashtable dbList, 
         Hashtable schemaList, DataSet columns, 
@@ -2536,11 +2536,11 @@ public abstract class AbstractSqlDataService : AbstractDataService
 	            SchemaItemType = schemaItemType
             };
             // generate a model element
-            if(schemaItemType == typeof(TableMappingItem))
+            if(schemaItemType == typeof(TableMapping))
             {
 	            var schemaService = ServiceManager.Services
 		            .GetService<ISchemaService>();
-	            var entity = new TableMappingItem();
+	            var entity = new TableMapping();
 	            entity.PersistenceProvider = provider;
 	            entity.SchemaExtensionId 
 		            = schemaService.ActiveSchemaExtensionId;
@@ -2599,10 +2599,10 @@ public abstract class AbstractSqlDataService : AbstractDataService
         foreach(DictionaryEntry entry in schemaList)
         {
             var process 
-	            = !((entry.Value is TableMappingItem tableMappingItem) 
+	            = !((entry.Value is TableMapping tableMappingItem) 
 	                && !tableMappingItem.GenerateDeploymentScript);
             if((entry.Value is DataEntityIndex dataEntityIndex) 
-               && (!((TableMappingItem)dataEntityIndex.ParentItem)
+               && (!((TableMapping)dataEntityIndex.ParentItem)
 	                   .GenerateDeploymentScript 
                    || !dataEntityIndex.GenerateDeploymentScript))
             {
@@ -2620,15 +2620,15 @@ public abstract class AbstractSqlDataService : AbstractDataService
 	            ParentSchemaItem = ((ISchemaItem)entry.Value).ParentItem,
 	            SchemaItemType = schemaItemType
             };
-            if(schemaItemType == typeof(TableMappingItem))
+            if(schemaItemType == typeof(TableMapping))
             {
-	            if(((TableMappingItem)result.SchemaItem).DatabaseObjectType 
+	            if(((TableMapping)result.SchemaItem).DatabaseObjectType 
 	               == DatabaseMappingObjectType.Table)
 	            {
 		            result.Script = sqlGenerator.TableDefinitionDdl(
-			            result.SchemaItem as TableMappingItem);
+			            result.SchemaItem as TableMapping);
 		            result.Script2 = sqlGenerator.ForeignKeyConstraintsDdl(
-			            result.SchemaItem as TableMappingItem);
+			            result.SchemaItem as TableMapping);
 	            }
 	            else
 	            {
@@ -2696,7 +2696,7 @@ public abstract class AbstractSqlDataService : AbstractDataService
 						var entityId = (Guid)table.ExtendedProperties["Id"];
 						var entity = GetEntity(entityId);
 						if(entity.EntityDefinition.GetType() 
-						   == typeof(TableMappingItem))
+						   == typeof(TableMapping))
 						{
 							newData.Clear();
 							LoadActualRow(newData, entityId, query.MethodId,

--- a/backend/Origam.DA.Service/Generators/AbstractSqlCommandGenerator.cs
+++ b/backend/Origam.DA.Service/Generators/AbstractSqlCommandGenerator.cs
@@ -155,7 +155,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
 
     public DbDataAdapter CreateDataAdapter(SelectParameters adParameters, bool forceDatabaseCalculation)
     {
-        if (!(adParameters.Entity.EntityDefinition is TableMappingItem))
+        if (!(adParameters.Entity.EntityDefinition is TableMapping))
         {
             throw new Exception(ResourceUtils.GetString("OnlyMappedEntitiesToBeProcessed"));
         }
@@ -194,7 +194,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         DataStructureEntity entity, DataStructureFilterSet filterSet,
         ColumnsInfo columnsInfo, bool forceDatabaseCalculation)
     {
-        if (!(entity.EntityDefinition is TableMappingItem))
+        if (!(entity.EntityDefinition is TableMapping))
         {
             throw new Exception(ResourceUtils.GetString("OnlyMappedEntitiesToBeProcessed"));
         }
@@ -208,7 +208,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return adapter;
     }
 
-    public DbDataAdapter CreateUpdateFieldDataAdapter(TableMappingItem table, FieldMappingItem field)
+    public DbDataAdapter CreateUpdateFieldDataAdapter(TableMapping table, FieldMappingItem field)
     {
         DbDataAdapter adapter = GetAdapter();
         BuildSelectUpdateFieldCommand(adapter, table, field);
@@ -218,7 +218,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return adapter;
     }
 
-    public IDbCommand UpdateFieldCommand(TableMappingItem entity, FieldMappingItem field)
+    public IDbCommand UpdateFieldCommand(TableMapping entity, FieldMappingItem field)
     {
         IDbCommand cmd = GetCommand(
             "UPDATE "
@@ -269,7 +269,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return dtm;
     }
 
-    private DataTableMapping CreateUpdateFieldMapping(TableMappingItem table, FieldMappingItem field)
+    private DataTableMapping CreateUpdateFieldMapping(TableMapping table, FieldMappingItem field)
     {
         DataTableMapping dtm = new DataTableMapping();
 
@@ -300,14 +300,14 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         BuildSelectParameters(adapter.SelectCommand, selectParameterReferences);
     }
 
-    public void BuildSelectUpdateFieldCommand(DbDataAdapter adapter, TableMappingItem table, FieldMappingItem field)
+    public void BuildSelectUpdateFieldCommand(DbDataAdapter adapter, TableMapping table, FieldMappingItem field)
     {
         ((IDbDataAdapter)adapter).SelectCommand = GetCommand(SelectUpdateFieldSql(table, field));
 
         BuildUpdateFieldParameters(((IDbDataAdapter)adapter).SelectCommand, field);
     }
 
-    public IDbCommand SelectReferenceCountCommand(TableMappingItem table, FieldMappingItem field)
+    public IDbCommand SelectReferenceCountCommand(TableMapping table, FieldMappingItem field)
     {
         IDbCommand cmd = GetCommand(SelectReferenceCountSql(table, field));
         cmd.CommandType = CommandType.Text;
@@ -575,7 +575,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
     {
         StringBuilder ddl = new StringBuilder();
 
-        foreach (TableMappingItem table in tables)
+        foreach (TableMapping table in tables)
         {
             if (table.DatabaseObjectType == DatabaseMappingObjectType.Table)
             {
@@ -587,7 +587,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
 
         return ddl.ToString();
     }
-    public string ForeignKeyConstraintsDdl(TableMappingItem table)
+    public string ForeignKeyConstraintsDdl(TableMapping table)
     {
         string result = "";
 
@@ -601,7 +601,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return result;
     }
 
-	public string AddForeignKeyConstraintDdl(TableMappingItem table, DataEntityConstraint constraint)
+	public string AddForeignKeyConstraintDdl(TableMapping table, DataEntityConstraint constraint)
     {
         StringBuilder ddl = new StringBuilder();
 
@@ -614,13 +614,13 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
     public string ParameterDeclarationChar =>
         sqlRenderer.ParameterDeclarationChar;
 
-    public string ForeignKeyConstraintDdl(TableMappingItem table, DataEntityConstraint constraint)
+    public string ForeignKeyConstraintDdl(TableMapping table, DataEntityConstraint constraint)
     {
         StringBuilder ddl = new StringBuilder();
 
-        if (constraint.ForeignEntity is TableMappingItem && constraint.Fields[0] is FieldMappingItem)
+        if (constraint.ForeignEntity is TableMapping && constraint.Fields[0] is FieldMappingItem)
         {
-            string pkTableName = (constraint.ForeignEntity as TableMappingItem).MappedObjectName;
+            string pkTableName = (constraint.ForeignEntity as TableMapping).MappedObjectName;
 
             ddl.AppendFormat("CONSTRAINT {1}",
                 sqlRenderer.NameLeftBracket + table.MappedObjectName + sqlRenderer.NameRightBracket,
@@ -662,12 +662,12 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         StringBuilder ddl = new StringBuilder();
 
         ddl.AppendFormat("ALTER TABLE {0} ADD {1}",
-            RenderExpression(field.ParentItem as TableMappingItem),
+            RenderExpression(field.ParentItem as TableMapping),
             ColumnDefinitionDdl(field));
 
         if (!field.AllowNulls && field.DefaultValue != null)
         {
-            string constraintName = "DF_" + (field.ParentItem as TableMappingItem).MappedObjectName + "_" + field.MappedColumnName;
+            string constraintName = "DF_" + (field.ParentItem as TableMapping).MappedObjectName + "_" + field.MappedColumnName;
             ddl.AppendFormat(" CONSTRAINT {0} DEFAULT {1};",
                 sqlRenderer.NameLeftBracket + constraintName + sqlRenderer.NameRightBracket,
                 this.RenderConstant(field.DefaultValue, false));
@@ -686,7 +686,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         StringBuilder ddl = new StringBuilder();
 
         ddl.AppendFormat("ALTER TABLE {0} ALTER COLUMN {1}",
-            RenderExpression(field.ParentItem as TableMappingItem),
+            RenderExpression(field.ParentItem as TableMapping),
             ChangeColumnDefinitionDdl(field));
         return ddl.ToString();
     }
@@ -727,7 +727,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         ddl.AppendFormat("CREATE {0} INDEX  {1} ON {2} (",
             (index.IsUnique ? "UNIQUE " : ""),
             sqlRenderer.NameLeftBracket + GetIndexName(entity, index) + sqlRenderer.NameRightBracket,
-            sqlRenderer.NameLeftBracket + (index.ParentItem as TableMappingItem).MappedObjectName + sqlRenderer.NameRightBracket
+            sqlRenderer.NameLeftBracket + (index.ParentItem as TableMapping).MappedObjectName + sqlRenderer.NameRightBracket
             );
 
         int i = 0;
@@ -768,7 +768,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         }
     }
 
-    public string TableDefinitionDdl(TableMappingItem table)
+    public string TableDefinitionDdl(TableMapping table)
     {
         if (table.DatabaseObjectType != DatabaseMappingObjectType.Table)
         {
@@ -1002,7 +1002,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         var rowOffset = selectParameters.RowOffset;
         bool rowOffsetSpecified = rowOffset.HasValue && rowOffset != 0;
 
-        if (!(entity.EntityDefinition is TableMappingItem))
+        if (!(entity.EntityDefinition is TableMapping))
         {
             throw new Exception("Only database mapped entities can be processed by the Data Service!");
         }
@@ -1595,7 +1595,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return sqlExpression.ToString();
     }
 
-    public string SelectUpdateFieldSql(TableMappingItem table, FieldMappingItem updatedField)
+    public string SelectUpdateFieldSql(TableMapping table, FieldMappingItem updatedField)
     {
         DataStructureEntity entity = new DataStructureEntity();
         entity.PersistenceProvider = table.PersistenceProvider;
@@ -1648,7 +1648,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return sqlExpression.ToString();
     }
 
-    public string SelectReferenceCountSql(TableMappingItem table, FieldMappingItem updatedField)
+    public string SelectReferenceCountSql(TableMapping table, FieldMappingItem updatedField)
     {
         DataStructureEntity entity = new DataStructureEntity();
         entity.PersistenceProvider = table.PersistenceProvider;
@@ -3115,8 +3115,8 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
     private string RenderExpression(ISchemaItem item, DataStructureEntity entity,
         Hashtable replaceParameterTexts, Hashtable dynamicParameters, Hashtable parameterReferences, bool renderSqlForDetachedFields)
     {
-        if (item is TableMappingItem)
-            return RenderExpression(item as TableMappingItem);
+        if (item is TableMapping)
+            return RenderExpression(item as TableMapping);
         if (item is EntityRelationItem)
             return RenderExpression(item as EntityRelationItem);
         else if (item is FieldMappingItem)
@@ -3364,7 +3364,7 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         return AggregationHelper(item, entity, item, replaceParameterTexts, 1, joins, dynamicParameters, parameterReferences);
     }
 
-    internal string RenderExpression(TableMappingItem item)
+    internal string RenderExpression(TableMapping item)
     {
         return sqlRenderer.NameLeftBracket + item.MappedObjectName + sqlRenderer.NameRightBracket;
     }
@@ -3381,18 +3381,18 @@ public abstract class AbstractSqlCommandGenerator : IDbDataAdapterFactory, IDisp
         bool localize 
             = dataStructureEntity?.RootItem is DataStructure dataStructure 
               && dataStructure.IsLocalized;
-        TableMappingItem tableMappingItem = null;
+        TableMapping tableMappingItem = null;
         FieldMappingItem localizedItem = null;
         if (localize)
         {
             tableMappingItem 
-                = dataStructureEntity.Entity as TableMappingItem;
+                = dataStructureEntity.Entity as TableMapping;
             if (tableMappingItem == null)
             {
                 // it could be a relation
                 if (dataStructureEntity.Entity is EntityRelationItem entityRelationItem)
                 {
-                    tableMappingItem = entityRelationItem.RelatedEntity as TableMappingItem;
+                    tableMappingItem = entityRelationItem.RelatedEntity as TableMapping;
                 }
             }
             localizedItem = fieldMappingItem.GetLocalizationField(tableMappingItem);

--- a/backend/Origam.DA.Service/Generators/DatasetGenerator.cs
+++ b/backend/Origam.DA.Service/Generators/DatasetGenerator.cs
@@ -677,7 +677,7 @@ public class DatasetGenerator
 			column.DefaultValue = RenderDefaultValue(finalColumn.Field.DefaultValue);
 		}
 	}
-	public DataSet CreateUpdateFieldDataSet(TableMappingItem table, FieldMappingItem field)
+	public DataSet CreateUpdateFieldDataSet(TableMapping table, FieldMappingItem field)
 	{
 		DataSet ds = new DataSet(dataSetName);
 		ds.Locale = System.Globalization.CultureInfo.CurrentUICulture;

--- a/backend/Origam.DA.Service/Generators/MsSqlCommandGenerator.cs
+++ b/backend/Origam.DA.Service/Generators/MsSqlCommandGenerator.cs
@@ -269,7 +269,7 @@ public class MsSqlCommandGenerator : AbstractSqlCommandGenerator
         string constraintName)
     {
         return string.Format("ALTER TABLE {0} DROP CONSTRAINT {1};",
-            RenderExpression(field.ParentItem as TableMappingItem),
+            RenderExpression(field.ParentItem as TableMapping),
             sqlRenderer.NameLeftBracket + constraintName +
             sqlRenderer.NameRightBracket);
     }

--- a/backend/Origam.DA.Service/Generators/PgSqlCommandGenerator.cs
+++ b/backend/Origam.DA.Service/Generators/PgSqlCommandGenerator.cs
@@ -249,7 +249,7 @@ public class PgSqlCommandGenerator : AbstractSqlCommandGenerator
     internal override string DropDefaultValue(FieldMappingItem field, string constraintName)
     {
         return string.Format("ALTER TABLE {0} ALTER COLUMN {1} DROP DEFAULT;",
-                RenderExpression(field.ParentItem as TableMappingItem),
+                RenderExpression(field.ParentItem as TableMapping),
                 sqlRenderer.NameLeftBracket + field.MappedColumnName + sqlRenderer.NameRightBracket);
     }
     

--- a/backend/Origam.DA.Service/Interfaces/IDbDataAdapterFactory.cs
+++ b/backend/Origam.DA.Service/Interfaces/IDbDataAdapterFactory.cs
@@ -44,14 +44,14 @@ public interface IDbDataAdapterFactory : ICloneable, IDisposable
         bool forceDatabaseCalculation);
 	IDbCommand ScalarValueCommand(DataStructure ds,  DataStructureFilterSet filter, 
         DataStructureSortSet sortSet, ColumnsInfo columnsInfo, Hashtable parameters);
-	IDbCommand UpdateFieldCommand(TableMappingItem entity,  FieldMappingItem field);
+	IDbCommand UpdateFieldCommand(TableMapping entity,  FieldMappingItem field);
 	IDbCommand GetCommand(string cmdText, IDbConnection connection);
 	IDbCommand GetCommand(string cmdText, IDbConnection connection, IDbTransaction transaction);
 	IDbCommand GetCommand(string cmdText);
 	IDbDataParameter GetParameter();
 	IDbDataParameter GetParameter(string name, Type type);
-	DbDataAdapter CreateUpdateFieldDataAdapter(TableMappingItem table, FieldMappingItem field);
-	IDbCommand SelectReferenceCountCommand(TableMappingItem table, FieldMappingItem field);
+	DbDataAdapter CreateUpdateFieldDataAdapter(TableMapping table, FieldMappingItem field);
+	IDbCommand SelectReferenceCountCommand(TableMapping table, FieldMappingItem field);
 	DbDataAdapter GetAdapter();
 	DbDataAdapter GetAdapter(IDbCommand command);
 	DbDataAdapter CloneAdapter(DbDataAdapter adapter);
@@ -59,9 +59,9 @@ public interface IDbDataAdapterFactory : ICloneable, IDisposable
 	List<string> Parameters(DataStructure ds, DataStructureEntity entity, 
         DataStructureFilterSet filter, DataStructureSortSet sort, bool paging,
         string columnName);
-    string TableDefinitionDdl(TableMappingItem table);
+    string TableDefinitionDdl(TableMapping table);
     string AddColumnDdl(FieldMappingItem field);
     string AlterColumnDdl(FieldMappingItem field);
-    string AddForeignKeyConstraintDdl(TableMappingItem table, DataEntityConstraint constraint);
+    string AddForeignKeyConstraintDdl(TableMapping table, DataEntityConstraint constraint);
 	string ParameterDeclarationChar { get; }
 }

--- a/backend/Origam.DA.Service/MetaModelUpgrade/UpdateScriptContainers/TableMappingScriptContainer.cs
+++ b/backend/Origam.DA.Service/MetaModelUpgrade/UpdateScriptContainers/TableMappingScriptContainer.cs
@@ -1,0 +1,50 @@
+#region license
+/*
+Copyright 2005 - 2024 Advantage Solutions, s. r. o.
+
+This file is part of ORIGAM (http://www.origam.org).
+
+ORIGAM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ORIGAM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Origam.DA.Service.MetaModelUpgrade.UpdateScriptContainers;
+class TableMappingScriptContainer : UpgradeScriptContainer
+{
+    public override string FullTypeName { get; } = typeof(Origam.Schema.EntityModel.TableMapping).FullName;
+    public override List<string> OldFullTypeNames { get; } = new List<string> { "Origam.Schema.EntityModel.TableMappingItem" };
+    public override string[] OldPropertyXmlNames { get; } = Array.Empty<string>();
+    public TableMappingScriptContainer()
+    {
+        upgradeScripts.Add(new UpgradeScript(
+            new Version("6.0.0"),
+            new Version("6.1.0"),
+            UpgradeTo610()));
+    }
+    private static Action<XElement, OrigamXDocument> UpgradeTo610()
+    {
+        return (node, doc) =>
+        {
+            if (node.Name.LocalName == "DataEntity" &&
+                node.Name.NamespaceName == "http://schemas.origam.com/Origam.Schema.EntityModel.TableMappingItem/6.0.0")
+            {
+                node.Name = "{http://schemas.origam.com/Origam.Schema.EntityModel.TableMapping/6.1.0}DataEntity";
+            }
+        };
+    }
+}

--- a/backend/Origam.DA.Service/MsSqlDataService.cs
+++ b/backend/Origam.DA.Service/MsSqlDataService.cs
@@ -195,7 +195,7 @@ public class MsSqlDataService : AbstractSqlDataService
                 }
             }
             bulk.DestinationTableName 
-                = (entity.EntityDefinition as TableMappingItem)
+                = (entity.EntityDefinition as TableMapping)
                 .MappedObjectName;
             bulk.BulkCopyTimeout = 1000;
             bulk.WriteToServer(table);
@@ -206,9 +206,9 @@ public class MsSqlDataService : AbstractSqlDataService
         IPersistenceService persistence = ServiceManager.Services.GetService(
             typeof(IPersistenceService)) as IPersistenceService;
         Guid entityId = (Guid)row.Table.ExtendedProperties["EntityId"];
-        TableMappingItem entity =
-            (TableMappingItem)persistence.SchemaProvider.RetrieveInstance(
-            typeof(TableMappingItem), new ModelElementKey(entityId));
+        TableMapping entity =
+            (TableMapping)persistence.SchemaProvider.RetrieveInstance(
+            typeof(TableMapping), new ModelElementKey(entityId));
         StringBuilder fieldNames = new StringBuilder();
         foreach (DataEntityIndex index in entity.EntityIndexes)
         {
@@ -441,7 +441,7 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0, 0)",
 	}
     internal override bool IsDataEntityIndexInDatabase(DataEntityIndex dataEntityIndex)
     {
-        string tableName = (dataEntityIndex.ParentItem as TableMappingItem)
+        string tableName = (dataEntityIndex.ParentItem as TableMapping)
             .MappedObjectName;
         string indexName = dataEntityIndex.Name;
         // from CompareSchema
@@ -470,10 +470,10 @@ VALUES (newid(), '{2}', '{0}', getdate(), 0, 0)",
         }
         return dbIndexList;
     }
-    internal override Hashtable GetSchemaIndexListGenerate(List<TableMappingItem> schemaTables, Hashtable dbTableList, Hashtable schemaIndexListAll)
+    internal override Hashtable GetSchemaIndexListGenerate(List<TableMapping> schemaTables, Hashtable dbTableList, Hashtable schemaIndexListAll)
     {
         Hashtable schemaIndexListGenerate = new Hashtable();
-        foreach (TableMappingItem t in schemaTables)
+        foreach (TableMapping t in schemaTables)
         {
             if (t.GenerateDeploymentScript & t.DatabaseObjectType == DatabaseMappingObjectType.Table)
             {

--- a/backend/Origam.DA.Service/PgSqlDataService.cs
+++ b/backend/Origam.DA.Service/PgSqlDataService.cs
@@ -386,7 +386,7 @@ group by ccu.table_name,tc.table_name,tc.constraint_name,tc.table_schema ";
 	}
     internal override bool IsDataEntityIndexInDatabase(DataEntityIndex dataEntityIndex)
     {
-        string tableName = (dataEntityIndex.ParentItem as TableMappingItem)
+        string tableName = (dataEntityIndex.ParentItem as TableMapping)
             .MappedObjectName;
         string indexName = dataEntityIndex.Name;
         // from CompareSchema
@@ -410,10 +410,10 @@ group by ccu.table_name,tc.table_name,tc.constraint_name,tc.table_schema ";
         }
         return dbIndexList;
     }
-    internal override Hashtable GetSchemaIndexListGenerate(List<TableMappingItem> schemaTables, Hashtable dbTableList, Hashtable schemaIndexListAll)
+    internal override Hashtable GetSchemaIndexListGenerate(List<TableMapping> schemaTables, Hashtable dbTableList, Hashtable schemaIndexListAll)
     {
         Hashtable schemaIndexListGenerate = new Hashtable();
-        foreach (TableMappingItem t in schemaTables)
+        foreach (TableMapping t in schemaTables)
         {
             if (t.GenerateDeploymentScript & t.DatabaseObjectType == DatabaseMappingObjectType.Table)
             {

--- a/backend/Origam.Gui.Win/Wizards/CreateLanguageTranslationEntityCommand.cs
+++ b/backend/Origam.Gui.Win/Wizards/CreateLanguageTranslationEntityCommand.cs
@@ -40,7 +40,7 @@ class CreateLanguageTranslationEntityCommand : AbstractMenuCommand
 	{
 		get
 		{				
-			return Owner is TableMappingItem;
+			return Owner is TableMapping;
 		}
 		set
 		{
@@ -50,7 +50,7 @@ class CreateLanguageTranslationEntityCommand : AbstractMenuCommand
 	public override void Run()
 	{
         var list = new List<ListViewItem>();
-        TableMappingItem mappingItem = new TableMappingItem();
+        TableMapping mappingItem = new TableMapping();
         list.Add(new ListViewItem(mappingItem.GetType().SchemaItemDescription().Name, mappingItem.Icon));
         Stack stackPage = new Stack();
         stackPage.Push(PagesList.Finish);
@@ -64,7 +64,7 @@ class CreateLanguageTranslationEntityCommand : AbstractMenuCommand
             PageTitle = "",
             Description = ResourceUtils.GetString("CreateLanguageTranslationEntityWizardDescription"),
             Pages = stackPage,
-            Entity = Owner as TableMappingItem,
+            Entity = Owner as TableMapping,
             IsRoleVisible = false,
             textColumnsOnly = true,
             ImageList = _schemaBrowser.EbrSchemaBrowser.imgList,
@@ -80,7 +80,7 @@ class CreateLanguageTranslationEntityCommand : AbstractMenuCommand
     {
         List<ISchemaItem> generatedElements = new List<ISchemaItem>();
         var table = EntityHelper.CreateLanguageTranslationChildEntity(
-            wizardForm.Entity as TableMappingItem, wizardForm.SelectedFields, generatedElements);
+            wizardForm.Entity as TableMapping, wizardForm.SelectedFields, generatedElements);
         foreach (var item in generatedElements)
         {
             GeneratedModelElements.Add(item);
@@ -100,6 +100,6 @@ class CreateLanguageTranslationEntityCommand : AbstractMenuCommand
         richTextBoxSummary.AppendText(Environment.NewLine);
         richTextBoxSummary.AppendText(Environment.NewLine);
         richTextBoxSummary.AppendText("Language Entity: \t");
-        richTextBoxSummary.AppendText(string.Format("{0}_l10n", (wizardForm.Entity as TableMappingItem).Name));
+        richTextBoxSummary.AppendText(string.Format("{0}_l10n", (wizardForm.Entity as TableMapping).Name));
     }
 }

--- a/backend/Origam.OrigamEngine/ModelXmlBuilders/FormXmlBuilder.cs
+++ b/backend/Origam.OrigamEngine/ModelXmlBuilders/FormXmlBuilder.cs
@@ -221,7 +221,7 @@ public class FormXmlBuilder
 	public static string DatabaseTableName(DataTable table)
 	{
 		IPersistenceService ps = ServiceManager.Services.GetService(typeof(IPersistenceService)) as IPersistenceService;
-		TableMappingItem tableMapping = ps.SchemaProvider.RetrieveInstance(typeof(TableMappingItem), new ModelElementKey((Guid)table.ExtendedProperties["EntityId"])) as TableMappingItem;
+		TableMapping tableMapping = ps.SchemaProvider.RetrieveInstance(typeof(TableMapping), new ModelElementKey((Guid)table.ExtendedProperties["EntityId"])) as TableMapping;
 		if(tableMapping != null)
 		{
 			return tableMapping.MappedObjectName;

--- a/backend/Origam.ReflectorCache/ReflectorCache.cs
+++ b/backend/Origam.ReflectorCache/ReflectorCache.cs
@@ -137,8 +137,8 @@ public class ReflectorCache : IReflectorCache
 				return new Origam.Schema.WorkflowModel.WorkflowCallTask(key);
 			case "Origam.Schema.DeploymentModel.DeploymentVersion":
 				return new Origam.Schema.DeploymentModel.DeploymentVersion(key);
-			case "Origam.Schema.EntityModel.TableMappingItem":
-				return new Origam.Schema.EntityModel.TableMappingItem(key);
+			case "Origam.Schema.EntityModel.TableMapping":
+				return new Origam.Schema.EntityModel.TableMapping(key);
 			case "Origam.Schema.MenuModel.FormReferenceMenuItem":
 				return new Origam.Schema.MenuModel.FormReferenceMenuItem(key);
 			case "Origam.Schema.EntityModel.DataStructureEntity":

--- a/backend/Origam.Schema.EntityModel.UI/Wizards/CreateChildEntityCommand.cs
+++ b/backend/Origam.Schema.EntityModel.UI/Wizards/CreateChildEntityCommand.cs
@@ -53,7 +53,7 @@ public class CreateChildEntityCommand : AbstractMenuCommand
 	{
 		IDataEntity entity = Owner as IDataEntity;
         var list = new List<ListViewItem>();
-        TableMappingItem table = new TableMappingItem();
+        TableMapping table = new TableMapping();
         DataEntityIndex entityIndex = new DataEntityIndex();
         EntityRelationItem entityRelation = new EntityRelationItem();
         list.Add(new ListViewItem(table.GetType().SchemaItemDescription().Name, table.Icon));
@@ -88,7 +88,7 @@ public class CreateChildEntityCommand : AbstractMenuCommand
     {
         IDataEntity entity1 = childEntityForm.Entity1;
         // 1. Create N:N Entity with reference to both entities
-        TableMappingItem newEntity = EntityHelper.CreateTable(childEntityForm.EntityName, childEntityForm.Entity1.Group, false);
+        TableMapping newEntity = EntityHelper.CreateTable(childEntityForm.EntityName, childEntityForm.Entity1.Group, false);
         newEntity.Persist();
         GeneratedModelElements.Add(newEntity);
         // Create index by parent entity

--- a/backend/Origam.Schema.EntityModel.UI/Wizards/LocalizeDatastructureCommand.cs
+++ b/backend/Origam.Schema.EntityModel.UI/Wizards/LocalizeDatastructureCommand.cs
@@ -47,7 +47,7 @@ public class LocalizeDatastructureCommand : AbstractMenuCommand
 		// (all fields = true)
 		foreach (DataStructureEntity dsEntity in ds.LocalizableEntities)
 		{
-			TableMappingItem table = dsEntity.Entity as TableMappingItem;
+			TableMapping table = dsEntity.Entity as TableMapping;
 			ISchemaService schema = ServiceManager.Services.GetService(typeof(ISchemaService)) as ISchemaService;
 			// create new datastructure entity using localization relation
 			DataStructureEntity localizationDSEntity 

--- a/backend/Origam.Schema.EntityModel/Data Structure/DataStructure.cs
+++ b/backend/Origam.Schema.EntityModel/Data Structure/DataStructure.cs
@@ -61,7 +61,7 @@ public class DataStructure : AbstractDataStructure, ISchemaItemFactory
             List<DataStructureEntity> result = new List<DataStructureEntity>();
             foreach (DataStructureEntity dsEntity in Entities)
             {
-                TableMappingItem table = dsEntity.Entity as TableMappingItem;
+                TableMapping table = dsEntity.Entity as TableMapping;
                 if (table != null && table.LocalizationRelation != null)
                 {
                     result.Add(dsEntity);

--- a/backend/Origam.Schema.EntityModel/EntityHelper.cs
+++ b/backend/Origam.Schema.EntityModel/EntityHelper.cs
@@ -188,14 +188,14 @@ public static class EntityHelper
 		}
 		return sortSetItem;
 	}
-    public static TableMappingItem CreateTable(
+    public static TableMapping CreateTable(
         string name, 
         SchemaItemGroup group,
         bool persist)
     {
         return CreateTable(name, group, persist, true);
     }
-    public static TableMappingItem CreateTable(
+    public static TableMapping CreateTable(
         string name, 
         SchemaItemGroup group, 
         bool persist, 
@@ -206,7 +206,7 @@ public static class EntityHelper
 		var entityModelSchemaItemProvider = schemaService
 			.GetProvider<EntityModelSchemaItemProvider>();
         var newEntity = entityModelSchemaItemProvider
-            .NewItem<TableMappingItem>(
+            .NewItem<TableMapping>(
 	            schemaService.StorageSchemaExtensionId, null);
 		newEntity.Name = name;
 		newEntity.MappedObjectName = name;
@@ -581,14 +581,14 @@ public static class EntityHelper
 		generatedElements?.Add(parameterReference);
 		return filter;
     }
-    public static TableMappingItem CreateLanguageTranslationChildEntity(
-        TableMappingItem parentEntity, ICollection selectedFields)
+    public static TableMapping CreateLanguageTranslationChildEntity(
+        TableMapping parentEntity, ICollection selectedFields)
     {
         return CreateLanguageTranslationChildEntity(
             parentEntity, selectedFields, null);
     }
-    public static TableMappingItem CreateLanguageTranslationChildEntity(
-        TableMappingItem parentEntity, ICollection selectedFields,
+    public static TableMapping CreateLanguageTranslationChildEntity(
+        TableMapping parentEntity, ICollection selectedFields,
         IList<ISchemaItem> generatedElements)
 	{			
 		var schemaService 

--- a/backend/Origam.Schema.EntityModel/EntityModelSchemaItemProvider.cs
+++ b/backend/Origam.Schema.EntityModel/EntityModelSchemaItemProvider.cs
@@ -46,13 +46,13 @@ public class EntityModelSchemaItemProvider : AbstractSchemaItemProvider
 	#region ISchemaItemFactory Members
 	public override Type[] NewItemTypes => new[]
 	{
-		typeof(TableMappingItem), typeof(DetachedEntity)
+		typeof(TableMapping), typeof(DetachedEntity)
 	};
 	public override T NewItem<T>(
 		Guid schemaExtensionId, SchemaItemGroup group)
 	{
 		T item;
-		if(typeof(T) == typeof(TableMappingItem))
+		if(typeof(T) == typeof(TableMapping))
 		{
 			item = base.NewItem<T>(schemaExtensionId, group, 
 				"NewTable");
@@ -69,7 +69,7 @@ public class EntityModelSchemaItemProvider : AbstractSchemaItemProvider
 				"This type is not supported by EntityModel");
 		}
 		// add default ancestor to all database entities
-		if(typeof(T) == typeof(TableMappingItem))
+		if(typeof(T) == typeof(TableMapping))
 		{
 			EntityHelper.AddAncestor(
 				item as IDataEntity, EntityHelper.DefaultAncestor, false);

--- a/backend/Origam.Schema.EntityModel/SchemaItems/DetachedEntity.cs
+++ b/backend/Origam.Schema.EntityModel/SchemaItems/DetachedEntity.cs
@@ -36,16 +36,16 @@ public class DetachedEntity : AbstractDataEntity
 	public DetachedEntity(Key primaryKey) : base(primaryKey)	{}
 //		public override bool CanConvertTo(Type type)
 //		{
-//			return (type == typeof(TableMappingItem));
+//			return (type == typeof(TableMapping));
 //		}
 //
 //		public override ISchemaItem ConvertTo(Type type)
 //		{
-//			if(type == typeof(TableMappingItem))
+//			if(type == typeof(TableMapping))
 //			{
 //				ArrayList ancestors = new ArrayList(this.Ancestors);
 //
-//				TableMappingItem converted = this.RootProvider.NewItem(type, this.SchemaExtensionId, this.Group) as TableMappingItem;
+//				TableMapping converted = this.RootProvider.NewItem(type, this.SchemaExtensionId, this.Group) as TableMapping;
 //
 //				converted.PrimaryKey["Id"] = this.PrimaryKey["Id"];
 //

--- a/backend/Origam.Schema.EntityModel/SchemaItems/FieldMappingItem.cs
+++ b/backend/Origam.Schema.EntityModel/SchemaItems/FieldMappingItem.cs
@@ -140,13 +140,13 @@ public class FieldMappingItem : AbstractDataEntityColumn,
 	}
 	#endregion
 	public static IDataEntity GetLocalizationTable(
-		TableMappingItem tableMappingItem)
+		TableMapping tableMappingItem)
 	{
 		return tableMappingItem?.LocalizationRelation?.AssociatedEntity;
 	}
 	[Browsable(false)]
 	public FieldMappingItem GetLocalizationField(
-		TableMappingItem tableMappingItem)
+		TableMapping tableMappingItem)
 	{
 		if((DataType != OrigamDataType.String) 
 		&& (DataType != OrigamDataType.Memo))

--- a/backend/Origam.Schema.EntityModel/SchemaItems/TableMapping.cs
+++ b/backend/Origam.Schema.EntityModel/SchemaItems/TableMapping.cs
@@ -40,12 +40,12 @@ public enum DatabaseMappingObjectType
 /// </summary>
 [SchemaItemDescription("Database Entity", "icon_database-entity.png")]
 [HelpTopic("Entities")]
-[ClassMetaVersion("6.0.0")]
-public class TableMappingItem : AbstractDataEntity
+[ClassMetaVersion("6.1.0")]
+public class TableMapping : AbstractDataEntity
 {
-	public TableMappingItem() {}
-	public TableMappingItem(Guid schemaExtensionId) : base(schemaExtensionId) {}
-	public TableMappingItem(Key primaryKey) : base(primaryKey)	{}
+	public TableMapping() {}
+	public TableMapping(Guid schemaExtensionId) : base(schemaExtensionId) {}
+	public TableMapping(Key primaryKey) : base(primaryKey)	{}
 	#region Properties
 	private string _sourceTableName;
 	[Category("Mapping")]

--- a/backend/Origam.Schema.LookupModel.UI/Wizards/CreateFieldWithLookupEntityCommand.cs
+++ b/backend/Origam.Schema.LookupModel.UI/Wizards/CreateFieldWithLookupEntityCommand.cs
@@ -56,7 +56,7 @@ public class CreateFieldWithLookupEntityCommand : AbstractMenuCommand
 	{
         FieldMappingItem baseField = Owner as FieldMappingItem;
         var list = new List<ListViewItem>();
-        TableMappingItem table1 = new TableMappingItem();
+        TableMapping table1 = new TableMapping();
         FieldMappingItem fieldMapping = new FieldMappingItem();
         DataServiceDataLookup data = new DataServiceDataLookup();
         list.Add(new ListViewItem(table1.GetType().SchemaItemDescription().Name, table1.Icon));
@@ -105,7 +105,7 @@ public class CreateFieldWithLookupEntityCommand : AbstractMenuCommand
             baseEntity = baseField.ParentItem as IDataEntity;
         }
         // 1. entity
-        TableMappingItem table = CreateLookupEntity(createFieldWith.LookupName, baseEntity,
+        TableMapping table = CreateLookupEntity(createFieldWith.LookupName, baseEntity,
             baseField);
         // 2. field "Name"
         FieldMappingItem nameField = EntityHelper.CreateColumn(table,
@@ -255,12 +255,12 @@ public class CreateFieldWithLookupEntityCommand : AbstractMenuCommand
     {
         return _schemaBrowser.ImageIndex(icon);
     }
-    private TableMappingItem CreateLookupEntity(
+    private TableMapping CreateLookupEntity(
        string LookupName, IDataEntity baseEntity,
         IDataEntityColumn baseField)
     {
         bool createAncestor = baseField == null;
-        TableMappingItem table = EntityHelper.CreateTable(
+        TableMapping table = EntityHelper.CreateTable(
             LookupName, baseEntity.Group, false, createAncestor);
         table.Persist();
         GeneratedModelElements.Add(table);

--- a/backend/Origam.Schema.LookupModel.UI/Wizards/CreateFieldWithRelationshipEntityCommand.cs
+++ b/backend/Origam.Schema.LookupModel.UI/Wizards/CreateFieldWithRelationshipEntityCommand.cs
@@ -61,7 +61,7 @@ public class CreateFieldWithRelationshipEntityCommand : AbstractMenuCommand
         //    Entity = baseEntity
         //};
         var list = new List<ListViewItem>();
-        TableMappingItem table1 = new TableMappingItem();
+        TableMapping table1 = new TableMapping();
         EntityRelationItem entityRelation = new EntityRelationItem();
         list.Add(new ListViewItem(table1.GetType().SchemaItemDescription().Name, table1.Icon));
         list.Add(new ListViewItem(entityRelation.GetType().SchemaItemDescription().Name, entityRelation.Icon));
@@ -94,7 +94,7 @@ public class CreateFieldWithRelationshipEntityCommand : AbstractMenuCommand
     {
         IDataEntity baseEntity = GetIDataEntity();
         // 1. entity
-        TableMappingItem table = (TableMappingItem)baseEntity;
+        TableMapping table = (TableMapping)baseEntity;
         GeneratedModelElements.Add(table);
         EntityRelationItem relation = EntityHelper.CreateRelation(table, (IDataEntity)wizardForm.RelatedEntity, wizardForm.ParentChildCheckbox, true);
         EntityHelper.CreateRelationKey(relation,

--- a/backend/Origam.Workbench.ServicesTests/FilePersistenceServiceTests/FilePersistenceServiceTests.cs
+++ b/backend/Origam.Workbench.ServicesTests/FilePersistenceServiceTests/FilePersistenceServiceTests.cs
@@ -34,7 +34,7 @@ public class FilePersistenceServiceTests: AbstractFileTestClass
         var sut = InitializeFilePersistenceService(pathToTestDirectory);
         bool reloadNeededEventCalled = false;
         var itemBeforeChange = sut.SchemaProvider
-            .RetrieveInstance<TableMappingItem>(testEntityId);
+            .RetrieveInstance<TableMapping>(testEntityId);
         
         Assert.That(itemBeforeChange.Name, Is.EqualTo("TestEntity"));
         
@@ -45,7 +45,7 @@ public class FilePersistenceServiceTests: AbstractFileTestClass
             Assert.IsTrue(maybeError.HasNoValue);
             
             var itemAfterChange = sut.SchemaProvider
-                .RetrieveInstance<TableMappingItem>(testEntityId);
+                .RetrieveInstance<TableMapping>(testEntityId);
             Assert.That(itemAfterChange.Name, Is.EqualTo("TestEntityChanged"));
         };
         string testFileContents = File.ReadAllText(pathToTestFile);

--- a/backend/Origam.Workflow/Service Agents/DataServiceAgent.cs
+++ b/backend/Origam.Workflow/Service Agents/DataServiceAgent.cs
@@ -256,7 +256,7 @@ public class DataServiceAgent : AbstractServiceAgent
 	
 	private int UpdateReferences(Guid entityId, object oldValue, object newValue)
 	{
-		TableMappingItem originalEntity = this.PersistenceProvider.RetrieveInstance(typeof(TableMappingItem), new ModelElementKey(entityId)) as TableMappingItem;
+		TableMapping originalEntity = this.PersistenceProvider.RetrieveInstance(typeof(TableMapping), new ModelElementKey(entityId)) as TableMapping;
 		if(originalEntity == null)
 		{
 			throw new ArgumentException(ResourceUtils.GetString("ErrorTableMappingNotFound", entityId.ToString()));
@@ -280,7 +280,7 @@ public class DataServiceAgent : AbstractServiceAgent
 		{
 			foreach(IDataEntity entity in entities.ChildItems)
 			{
-				TableMappingItem table = entity as TableMappingItem;
+				TableMapping table = entity as TableMapping;
 				if(table != null && table.DatabaseObjectType == DatabaseMappingObjectType.Table && table.GenerateDeploymentScript)
 				{
 					foreach(IDataEntityColumn column in table.EntityColumns)
@@ -333,7 +333,7 @@ public class DataServiceAgent : AbstractServiceAgent
 	}
 	private int ReferenceCount(Guid entityId, object value)
 	{
-		TableMappingItem originalEntity = this.PersistenceProvider.RetrieveInstance(typeof(TableMappingItem), new ModelElementKey(entityId)) as TableMappingItem;
+		TableMapping originalEntity = this.PersistenceProvider.RetrieveInstance(typeof(TableMapping), new ModelElementKey(entityId)) as TableMapping;
 		if(originalEntity == null)
 		{
 			throw new ArgumentException(ResourceUtils.GetString("ErrorTableMappingNotFound", entityId.ToString()));
@@ -357,7 +357,7 @@ public class DataServiceAgent : AbstractServiceAgent
 		{
 			if(!skipRelationships.Contains(entity))
 			{
-				TableMappingItem table = entity as TableMappingItem;
+				TableMapping table = entity as TableMapping;
 				if(table != null && table.DatabaseObjectType == DatabaseMappingObjectType.Table && table.GenerateDeploymentScript)
 				{
 					foreach(IDataEntityColumn column in table.EntityColumns)

--- a/backend/Origam.Workflow/Service Agents/ModelServiceAgent.cs
+++ b/backend/Origam.Workflow/Service Agents/ModelServiceAgent.cs
@@ -187,7 +187,7 @@ public class ModelServiceAgent : AbstractServiceAgent
                         resultTable, field, documentationService);
                     continue;
                 }
-                case TableMappingItem
+                case TableMapping
                 {
                     DatabaseObjectType: DatabaseMappingObjectType.View
                 }:
@@ -197,7 +197,7 @@ public class ModelServiceAgent : AbstractServiceAgent
                 default:
                 {
                     AddDatabaseFieldToResultTable(
-                        resultTable, field, field.ParentItem as TableMappingItem, 
+                        resultTable, field, field.ParentItem as TableMapping, 
                         documentationService);
                     break;
                 }
@@ -210,9 +210,9 @@ public class ModelServiceAgent : AbstractServiceAgent
         FieldMappingItem fieldMappingItem,
         IDocumentationService documentationService)
     {
-        List<TableMappingItem> tableMappingItems 
-            = persistenceService.SchemaProvider.RetrieveList<TableMappingItem>();
-        foreach (TableMappingItem tableMappingItem in tableMappingItems)
+        List<TableMapping> tableMappingItems 
+            = persistenceService.SchemaProvider.RetrieveList<TableMapping>();
+        foreach (TableMapping tableMappingItem in tableMappingItems)
         {
             if (tableMappingItem.DatabaseObjectType
                 == DatabaseMappingObjectType.View)
@@ -233,7 +233,7 @@ public class ModelServiceAgent : AbstractServiceAgent
     private void AddDatabaseFieldToResultTable(
         DataTable resultTable,
         FieldMappingItem fieldMappingItem,
-        TableMappingItem parentTableMappingItem,
+        TableMapping parentTableMapping,
         IDocumentationService documentationService)
     {
         DataRow row = resultTable.NewRow();
@@ -244,14 +244,14 @@ public class ModelServiceAgent : AbstractServiceAgent
         row["DefaultValue"] = fieldMappingItem.DefaultValue;
         row["PackageName"] = fieldMappingItem.PackageName;
         row["ForeignKeyEntity"] = 
-            (fieldMappingItem.ForeignKeyEntity as TableMappingItem)
+            (fieldMappingItem.ForeignKeyEntity as TableMapping)
             ?.MappedObjectName ?? "";
         row["ForeignKeyField"] = 
             (fieldMappingItem.ForeignKeyField as FieldMappingItem)
             ?.MappedColumnName ?? "";
         row["IsPrimaryKey"] = fieldMappingItem.IsPrimaryKey;
         row["Name"] = fieldMappingItem.MappedColumnName;
-        row["ParentEntityName"] = parentTableMappingItem.MappedObjectName;
+        row["ParentEntityName"] = parentTableMapping.MappedObjectName;
         row["UserShortHelp"] = documentationService.GetDocumentation(
             fieldMappingItem.Id, DocumentationType.USER_SHORT_HELP);
         row["UserLongHelp"] = documentationService.GetDocumentation(

--- a/backend/OrigamArchitect/ArchitectWorkbench.cs
+++ b/backend/OrigamArchitect/ArchitectWorkbench.cs
@@ -1787,12 +1787,12 @@ public void OpenForm(object owner,Hashtable parameters)
 			ShowDocumentation cmd = new ShowDocumentation();
 			cmd.Run();
 		}
-		if(_schema.ActiveNode is TableMappingItem)
+		if(_schema.ActiveNode is TableMapping)
 		{
 			try
 			{
-				_outputPad.SetOutputText(abstractSqlCommandGenerator.TableDefinitionDdl(_schema.ActiveNode as TableMappingItem));
-				_outputPad.AppendText(abstractSqlCommandGenerator.ForeignKeyConstraintsDdl(_schema.ActiveNode as TableMappingItem));
+				_outputPad.SetOutputText(abstractSqlCommandGenerator.TableDefinitionDdl(_schema.ActiveNode as TableMapping));
+				_outputPad.AppendText(abstractSqlCommandGenerator.ForeignKeyConstraintsDdl(_schema.ActiveNode as TableMapping));
 			}
 			catch(Exception ex)
 			{


### PR DESCRIPTION
## Summary
- add `TableMapping` schema class as successor of `TableMappingItem`
- migrate meta-model with `TableMappingScriptContainer`
- remove obsolete `TableMappingItem` file and fix upgrader property

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*