### PR TITLE
Fix jest matchers for v30

### DIFF
--- a/frontend-html/src/dic/Container.test.ts
+++ b/frontend-html/src/dic/Container.test.ts
@@ -234,8 +234,8 @@ describe("Container", () => {
 
     const d = container4.resolve(IDog);
 
-    expect(() => container1.resolve(IDog)).toThrowError();
-    expect(() => container2.resolve(IDog)).toThrowError();
+    expect(() => container1.resolve(IDog)).toThrow();
+    expect(() => container2.resolve(IDog)).toThrow();
 
     const dogs = [
       container3.resolve(IDog),


### PR DESCRIPTION
## Summary
- adjust `Container.test.ts` to use `toThrow` instead of removed `toThrowError`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_b_6874ada388f08324b1d8542c4bcfe1cf