### PR TITLE
Fix xstate v5 migration

### DIFF
--- a/frontend-html/src/utils/mouse.ts
+++ b/frontend-html/src/utils/mouse.ts
@@ -17,13 +17,24 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { createMachine, interpret } from "xstate";
+import { createMachine, createActor, setup } from "xstate";
+
+interface MouseContext {}
+
+interface MouseDownEvent {
+  type: "MOUSE_DOWN";
+  payload: { domEvent: globalThis.MouseEvent };
+}
 
 export function preventDoubleclickSelect() {
-  const interpreter = interpret(
-    createMachine(
+  const interpreter = createActor(
+    setup({
+      types: {
+        context: {} as MouseContext,
+        events: {} as MouseDownEvent,
+      },
+    }).createMachine(
       {
-        predictableActionArguments: true,
         id: "selectionPreventer",
         initial: "IDLE",
         states: {
@@ -31,7 +42,7 @@ export function preventDoubleclickSelect() {
             on: {
               MOUSE_DOWN: {
                 target: "DEAD_PERIOD",
-                cond: "isNotEditable",
+                guard: "isNotEditable",
               },
             },
           },


### PR DESCRIPTION
## Summary
- adapt mouse doubleclick select prevention to xstate v5 API
- use `setup`, `fromPromise`, and `fromCallback` in PeriodicLoader

## Testing
- `npx tsc -p ./tsconfig.json` *(fails: Cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_b_6874b373344c832493ac69d4cfb7e5f0