### PR TITLE
feat: bundle MiniProfiler libraries in installers

### DIFF
--- a/backend/OrigamSetup/ArchitectSetup.wxs
+++ b/backend/OrigamSetup/ArchitectSetup.wxs
@@ -70,6 +70,18 @@
               <File Id="SYSTEM.DIAGNOSTICS.DIAGNOSTICSOURCE.DLL" Name="System.Diagnostics.DiagnosticSource.dll" Source="source\System.Diagnostics.DiagnosticSource.dll">
               </File>
             </Component>
+            <Component Id="MINIPROFILER.ASPNETCORE.DLL" DiskId="1" Guid="6135B499-AF3C-4551-BA38-1CAF5FE3F563">
+              <File Id="MINIPROFILER.ASPNETCORE.DLL" Name="MiniProfiler.AspNetCore.dll" Source="source\MiniProfiler.AspNetCore.dll" />
+            </Component>
+            <Component Id="MINIPROFILER.ASPNETCORE.MVC.DLL" DiskId="1" Guid="63CFCE32-4412-4196-920E-F9AACCB1FA73">
+              <File Id="MINIPROFILER.ASPNETCORE.MVC.DLL" Name="MiniProfiler.AspNetCore.Mvc.dll" Source="source\MiniProfiler.AspNetCore.Mvc.dll" />
+            </Component>
+            <Component Id="MINIPROFILER.MINIMAL.DLL" DiskId="1" Guid="AE5210A9-0410-42A1-8B7C-AE18252253DF">
+              <File Id="MINIPROFILER.MINIMAL.DLL" Name="MiniProfiler.Minimal.dll" Source="source\MiniProfiler.Minimal.dll" />
+            </Component>
+            <Component Id="MINIPROFILER.SHARED.DLL" DiskId="1" Guid="E28A0CAB-56E0-4D48-888E-C0C4F9408CAA">
+              <File Id="MINIPROFILER.SHARED.DLL" Name="MiniProfiler.Shared.dll" Source="source\MiniProfiler.Shared.dll" />
+            </Component>
             <Component Id="ORIGAM.EXCEL.DLL" DiskId="1" Guid="32F0928A-4B26-4A4B-AB80-3564E8AF13A8">
               <File Id="ORIGAM.EXCEL.DLL" Name="Origam.Excel.dll" Source="source\Origam.Excel.dll">
               </File>
@@ -651,6 +663,10 @@
 	  <ComponentRef Id="MICROSOFT.EXTENSIONS.LOGGING.ABSTRACTIONS.DLL"></ComponentRef>
       <ComponentRef Id="SYSTEM.TEXT.JSON.DLL"></ComponentRef>
       <ComponentRef Id="SYSTEM.DIAGNOSTICS.DIAGNOSTICSOURCE.DLL"></ComponentRef>
+      <ComponentRef Id="MINIPROFILER.ASPNETCORE.DLL"></ComponentRef>
+      <ComponentRef Id="MINIPROFILER.ASPNETCORE.MVC.DLL"></ComponentRef>
+      <ComponentRef Id="MINIPROFILER.MINIMAL.DLL"></ComponentRef>
+      <ComponentRef Id="MINIPROFILER.SHARED.DLL"></ComponentRef>
       <ComponentRef Id="ORIGAM.EXCEL.DLL"></ComponentRef>
       <ComponentRef Id="AEROWIZARD.DLL">
       </ComponentRef>

--- a/backend/OrigamSetup/ServerSetup.wxs
+++ b/backend/OrigamSetup/ServerSetup.wxs
@@ -616,6 +616,18 @@
                             <Component Id="MICROSOFT.VBE.INTEROP.DLL" DiskId="1" Guid="7BB9250B-6E01-406F-B168-9790955366A7">
                                 <File Id="MICROSOFT.VBE.INTEROP.DLL" Name="Microsoft.Vbe.Interop.dll" Source="server_source\bin\Microsoft.Vbe.Interop.dll" />
                             </Component>
+            <Component Id="MINIPROFILER.ASPNETCORE.DLL" DiskId="1" Guid="7388850F-9A21-473D-8618-B9C53362F271">
+                <File Id="MINIPROFILER.ASPNETCORE.DLL" Name="MiniProfiler.AspNetCore.dll" Source="server_source\bin\MiniProfiler.AspNetCore.dll" />
+            </Component>
+            <Component Id="MINIPROFILER.ASPNETCORE.MVC.DLL" DiskId="1" Guid="19DF4B83-B1D4-45B0-A9A9-5CDD4368D0F3">
+                <File Id="MINIPROFILER.ASPNETCORE.MVC.DLL" Name="MiniProfiler.AspNetCore.Mvc.dll" Source="server_source\bin\MiniProfiler.AspNetCore.Mvc.dll" />
+            </Component>
+            <Component Id="MINIPROFILER.MINIMAL.DLL" DiskId="1" Guid="A6F9F44B-B9E4-433C-BFA3-77DA9DB9F8F0">
+                <File Id="MINIPROFILER.MINIMAL.DLL" Name="MiniProfiler.Minimal.dll" Source="server_source\bin\MiniProfiler.Minimal.dll" />
+            </Component>
+            <Component Id="MINIPROFILER.SHARED.DLL" DiskId="1" Guid="4C98A43A-561B-4CD9-86F4-2BA81623528F">
+                <File Id="MINIPROFILER.SHARED.DLL" Name="MiniProfiler.Shared.dll" Source="server_source\bin\MiniProfiler.Shared.dll" />
+            </Component>
                             <Component Id="MIMEPARSER.DLL" DiskId="1" Guid="7CF3B39F-EEDF-4EF2-B15F-F09193F8786C">
                                 <File Id="MIMEPARSER.DLL" Name="MIMEParser.dll" Source="server_source\bin\MIMEParser.dll" />
                             </Component>
@@ -1391,6 +1403,10 @@
             <ComponentRef Id="MICROSOFT.PRACTICES.ENTERPRISELIBRARY.CONFIGURATION.DLL" />
             <ComponentRef Id="MICROSOFT.PRACTICES.ENTERPRISELIBRARY.SECURITY.DLL" />
             <ComponentRef Id="MICROSOFT.VBE.INTEROP.DLL" />
+            <ComponentRef Id="MINIPROFILER.ASPNETCORE.DLL" />
+            <ComponentRef Id="MINIPROFILER.ASPNETCORE.MVC.DLL" />
+            <ComponentRef Id="MINIPROFILER.MINIMAL.DLL" />
+            <ComponentRef Id="MINIPROFILER.SHARED.DLL" />
             <ComponentRef Id="MIMEPARSER.DLL" />
             <ComponentRef Id="NANDOF.DLL" />
             <ComponentRef Id="NEON.DLL" />

--- a/build/build-monorepo.yaml
+++ b/build/build-monorepo.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2022_1.yaml
+++ b/build/build-monorepo_2022_1.yaml
@@ -115,7 +115,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2022_2.yaml
+++ b/build/build-monorepo_2022_2.yaml
@@ -115,7 +115,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2022_3.yaml
+++ b/build/build-monorepo_2022_3.yaml
@@ -115,7 +115,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2022_4.yaml
+++ b/build/build-monorepo_2022_4.yaml
@@ -123,7 +123,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2023_1.yaml
+++ b/build/build-monorepo_2023_1.yaml
@@ -123,7 +123,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2023_2.yaml
+++ b/build/build-monorepo_2023_2.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_1.yaml
+++ b/build/build-monorepo_2024_1.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_10.yaml
+++ b/build/build-monorepo_2024_10.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_11.yaml
+++ b/build/build-monorepo_2024_11.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_12.yaml
+++ b/build/build-monorepo_2024_12.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_2.yaml
+++ b/build/build-monorepo_2024_2.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_3.yaml
+++ b/build/build-monorepo_2024_3.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_4.yaml
+++ b/build/build-monorepo_2024_4.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_5.yaml
+++ b/build/build-monorepo_2024_5.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_6.yaml
+++ b/build/build-monorepo_2024_6.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_7.yaml
+++ b/build/build-monorepo_2024_7.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_8.yaml
+++ b/build/build-monorepo_2024_8.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2024_9.yaml
+++ b/build/build-monorepo_2024_9.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_1.yaml
+++ b/build/build-monorepo_2025_1.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_2.yaml
+++ b/build/build-monorepo_2025_2.yaml
@@ -121,7 +121,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_3.yaml
+++ b/build/build-monorepo_2025_3.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_4.yaml
+++ b/build/build-monorepo_2025_4.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_5.yaml
+++ b/build/build-monorepo_2025_5.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_6.yaml
+++ b/build/build-monorepo_2025_6.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_7.yaml
+++ b/build/build-monorepo_2025_7.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build-monorepo_2025_8.yaml
+++ b/build/build-monorepo_2025_8.yaml
@@ -112,7 +112,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()

--- a/build/build_monorepo_2021_1.yml
+++ b/build/build_monorepo_2021_1.yml
@@ -114,7 +114,12 @@ jobs:
        displayName: 'Copy external architect dlls to: $(build.artifactstagingdirectory)\origam-architect'
        inputs:
          SourceFolder: '$(Agent.BuildDirectory)\s\backend\'
-         Contents: 'EnterpriseLibrary\Interop.MSCommLib.dll'
+         Contents: |
+          EnterpriseLibrary\Interop.MSCommLib.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.dll
+          EnterpriseLibrary\MiniProfiler.AspNetCore.Mvc.dll
+          EnterpriseLibrary\MiniProfiler.Minimal.dll
+          EnterpriseLibrary\MiniProfiler.Shared.dll
          TargetFolder: '$(build.artifactstagingdirectory)\origam-architect'
          flattenFolders: true
        condition: succeededOrFailed()


### PR DESCRIPTION
## Summary
- include MiniProfiler ASP.NET components in server installer
- ship MiniProfiler libraries with Architect installer
- copy MiniProfiler DLLs during build pipelines

## Testing
- `dotnet test backend/Origam.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68aeca497a2c8324a4b5422a2529c954