### PR TITLE
FIX: It was not possible to open any screens in architect

### DIFF
--- a/backend/Origam.Gui.Designer/ControlSetEditor.cs
+++ b/backend/Origam.Gui.Designer/ControlSetEditor.cs
@@ -543,7 +543,9 @@ public class ControlSetEditor : AbstractEditor
 			throw new ArgumentException("Parameter is null or inner parameters are null", "cntrlSet");
 	
 		Type type;
-		Assembly asm = Assembly.Load(cntrlSet.ControlItem.ControlNamespace);
+#pragma warning disable CS0618 // Type or member is obsolete
+		Assembly asm = Assembly.LoadWithPartialName(cntrlSet.ControlItem.ControlNamespace);
+#pragma warning restore CS0618 // Type or member is obsolete
 		type = asm.GetType(cntrlSet.ControlItem.ControlType);
 		if(type==null)
 			throw new NullReferenceException("Unsupported type:" + cntrlSet.ControlItem.ControlType);

--- a/backend/Origam.Gui.Designer/impls/ToolboxPane.cs
+++ b/backend/Origam.Gui.Designer/impls/ToolboxPane.cs
@@ -387,7 +387,9 @@ public class ToolboxPane : System.Windows.Forms.UserControl
 		// try to load it with a partial name
 		// Assembly asm = Assembly.Load(classname + "," + assembly);
 		
-		Assembly asm = Assembly.Load(assembly);
+#pragma warning disable CS0618 // Type or member is obsolete, Assembly.Load(classname + "," + assembly); does not work
+		Assembly asm = Assembly.LoadWithPartialName(assembly);
+#pragma warning restore CS0618 // Type or member is obsolete
 		if(asm!=null)
 		{
 			return asm.GetType(classname);


### PR DESCRIPTION
threw error: Could not load file or assembly 'System.Windows.Forms' or one of its dependencies. The system cannot find the file specified.