### PR TITLE
chore(e2e): bump vulnerable test dependencies

### DIFF
--- a/test/tests_e2e/package.json
+++ b/test/tests_e2e/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "dependencies": {
     "@babel/helper-get-function-arity": "^7.16.7",
-    "jest": "^27.3.1",
+    "jest": "^30.2.0",
     "jest-trx-results-processor": "^3.0.2",
-    "msnodesqlv8": "^4.1.2",
-    "mssql": "^7.2.1",
-    "puppeteer": "^10.1.0"
+    "msnodesqlv8": "^5.1.1",
+    "mssql": "^11.0.1",
+    "puppeteer": "^24.4.0"
   },
   "homepage": "./",
   "jest": {
@@ -25,7 +25,7 @@
     ]
   },
   "devDependencies": {
-    "@types/uuid": "^8.3.1",
-    "jest-image-snapshot": "^4.5.1"
+    "@types/uuid": "^11.0.0",
+    "jest-image-snapshot": "^6.5.1"
   }
 }


### PR DESCRIPTION
### Motivation
- Address Dependabot/security advisories by upgrading vulnerable dependencies used by the end-to-end test package so the test toolchain uses supported versions.

### Description
- Updated `test/tests_e2e/package.json` to bump `jest` to `^30.2.0`, `puppeteer` to `^24.4.0`, `mssql` to `^11.0.1`, `msnodesqlv8` to `^5.1.1`, `@types/uuid` to `^11.0.0`, and `jest-image-snapshot` to `^6.5.1`.

### Testing
- Attempted to refresh and verify dependencies with `yarn up`, `npm outdated` and `yarn npm audit`, but network/registry requests returned HTTP 403 in this environment so lockfile regeneration and runtime verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aaf81daf308324ad7b0f066176dae8)