### PR TITLE
DEV: @vitejs/plugin-react version pinned

### DIFF
--- a/frontend-html/package.json
+++ b/frontend-html/package.json
@@ -83,7 +83,7 @@
     "@types/react-beautiful-dnd": "^13.1.8",
     "@types/react-dom": "^18.3.1",
     "@types/uuid": "^11.0.0",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "5.1.x",
     "browserslist": "^4.28.2",
     "browserslist-useragent-regexp": "^4.1.4",
     "esbuild": "^0.28.0",

--- a/frontend-html/yarn.lock
+++ b/frontend-html/yarn.lock
@@ -3139,7 +3139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-react@npm:^5.1.4":
+"@vitejs/plugin-react@npm:5.1.x":
   version: 5.1.4
   resolution: "@vitejs/plugin-react@npm:5.1.4"
   dependencies:
@@ -6958,7 +6958,7 @@ __metadata:
     "@types/react-virtualized": "npm:^9.22.3"
     "@types/uuid": "npm:^11.0.0"
     "@vitejs/plugin-basic-ssl": "npm:^2.3.0"
-    "@vitejs/plugin-react": "npm:^5.1.4"
+    "@vitejs/plugin-react": "npm:5.1.x"
     "@xstate/inspect": "npm:^0.8.0"
     axios: "npm:^1.15.0"
     bind-decorator: "npm:^1.0.11"


### PR DESCRIPTION
because it cannot be upgraded now. Maybe after we get rid of legacy decorators and upgrade react it will be possible