### PR TITLE
DEV: Remove Axios dependency from /architect-html

### DIFF
--- a/architect-html/.npmrc
+++ b/architect-html/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/architect-html/.yarnrc
+++ b/architect-html/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/architect-html/.yarnrc.yml
+++ b/architect-html/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+enableScripts: false

--- a/architect-html/package.json
+++ b/architect-html/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.29.0",
     "@monaco-editor/react": "^4.7.0",
-    "axios": "^1.13.6",
     "classnames": "^2.5.1",
     "lodash": "^4.18.1",
     "mobx": "^6.15.0",

--- a/architect-html/src/API/ArchitectApi.ts
+++ b/architect-html/src/API/ArchitectApi.ts
@@ -40,52 +40,32 @@ import {
   IValidationResult,
   ShemaItemInfo,
 } from '@api/IArchitectApi';
-import axios, { AxiosInstance } from 'axios';
+import { HttpClient } from '@api/httpClient';
 
 export class ArchitectApi implements IArchitectApi {
   errorHandler: (error: any) => void;
-  axiosInstance: AxiosInstance;
+  http: HttpClient;
 
   constructor(errorHandler?: (error: any) => void) {
-    this.axiosInstance = this.createAxiosInstance();
     this.errorHandler = errorHandler ?? simpleErrorHandler;
-  }
-
-  private createAxiosInstance() {
-    const axiosInstance = axios.create({});
-
-    axiosInstance.interceptors.response.use(
-      response => {
-        return response;
-      },
-      async error => {
-        if (error.response?.data?.constructor?.name === 'Blob') {
-          error.response.data = await error.response.data.text();
-        }
-        if (!axios.isCancel(error)) {
-          this.errorHandler(error);
-        }
-        throw error;
-      },
-    );
-    return axiosInstance;
+    this.http = new HttpClient(error => this.errorHandler(error));
   }
 
   async setActivePackage(packageId: string): Promise<void> {
-    await this.axiosInstance.post('/Package/SetActive', { id: packageId });
+    await this.http.post('/Package/SetActive', { id: packageId });
   }
 
   async getPackages(): Promise<IPackagesInfo> {
-    return (await this.axiosInstance.get('/Package/GetAll')).data;
+    return (await this.http.get('/Package/GetAll')).data;
   }
 
   async getTopModelNodes(): Promise<IApiTreeNode[]> {
-    return (await this.axiosInstance.get(`/Model/GetTopNodes`)).data;
+    return (await this.http.get(`/Model/GetTopNodes`)).data;
   }
 
   async getNodeChildren(node: IApiTreeNode): Promise<IApiTreeNode[]> {
     return (
-      await this.axiosInstance.get(`/Model/GetChildren`, {
+      await this.http.get(`/Model/GetChildren`, {
         params: {
           id: node.origamId,
           nodeText: node.nodeText,
@@ -97,7 +77,7 @@ export class ArchitectApi implements IArchitectApi {
 
   async searchText(text: string): Promise<ISearchResult[]> {
     return (
-      await this.axiosInstance.get('/Search/Text', {
+      await this.http.get('/Search/Text', {
         params: {
           text,
         },
@@ -107,7 +87,7 @@ export class ArchitectApi implements IArchitectApi {
 
   async searchReferences(schemaItemId: string): Promise<ISearchResult[]> {
     return (
-      await this.axiosInstance.get('/Search/References', {
+      await this.http.get('/Search/References', {
         params: {
           schemaItemId,
         },
@@ -117,7 +97,7 @@ export class ArchitectApi implements IArchitectApi {
 
   async searchDependencies(schemaItemId: string): Promise<ISearchResult[]> {
     return (
-      await this.axiosInstance.get('/Search/Dependencies', {
+      await this.http.get('/Search/Dependencies', {
         params: {
           schemaItemId,
         },
@@ -126,18 +106,15 @@ export class ArchitectApi implements IArchitectApi {
   }
 
   async openEditor(schemaItemId: string): Promise<IApiEditorData> {
-    return (await this.axiosInstance.post('/Editor/OpenEditor', { schemaItemId: schemaItemId }))
-      .data;
+    return (await this.http.post('/Editor/OpenEditor', { schemaItemId: schemaItemId })).data;
   }
 
   async closeEditor(editorId: string) {
-    await this.axiosInstance.post('/Editor/CloseEditor', { editorId: editorId });
+    await this.http.post('/Editor/CloseEditor', { editorId: editorId });
   }
 
   async openDocumentationEditor(schemaItemId: string): Promise<IApiEditorData> {
-    return (
-      await this.axiosInstance.post('/Documentation/OpenEditor', { schemaItemId: schemaItemId })
-    ).data;
+    return (await this.http.post('/Documentation/OpenEditor', { schemaItemId: schemaItemId })).data;
   }
 
   async updateDocumentationProperties(
@@ -145,7 +122,7 @@ export class ArchitectApi implements IArchitectApi {
     changes: IPropertyChange[],
   ): Promise<IUpdatePropertiesResult> {
     return (
-      await this.axiosInstance.post(`/Documentation/Update`, {
+      await this.http.post(`/Documentation/Update`, {
         schemaItemId,
         changes,
       })
@@ -153,39 +130,39 @@ export class ArchitectApi implements IArchitectApi {
   }
 
   async persistDocumentationChanges(schemaItemId: string): Promise<void> {
-    await this.axiosInstance.post(`/Documentation/PersistChanges`, {
+    await this.http.post(`/Documentation/PersistChanges`, {
       schemaItemId,
     });
   }
 
   async validateTransformation(input: ITransformationInput): Promise<IValidationResult> {
-    return (await this.axiosInstance.post(`/Xslt/Validate`, input)).data;
+    return (await this.http.post(`/Xslt/Validate`, input)).data;
   }
 
   async runTransformation(input: ITransformationInput): Promise<ITransformResult> {
-    return (await this.axiosInstance.post(`/Xslt/Transform`, input)).data;
+    return (await this.http.post(`/Xslt/Transform`, input)).data;
   }
 
   async getXsltParameters(schemaItemId: string): Promise<IParametersResult> {
-    return (await this.axiosInstance.get(`/Xslt/Parameters`, { params: { schemaItemId } })).data;
+    return (await this.http.get(`/Xslt/Parameters`, { params: { schemaItemId } })).data;
   }
 
   async getXsltSettings(): Promise<ShemaItemInfo[]> {
-    return (await this.axiosInstance.get(`/Xslt/Settings`)).data;
+    return (await this.http.get(`/Xslt/Settings`)).data;
   }
 
   async getRuleSets(dataStructureId: string): Promise<ShemaItemInfo[]> {
-    return (await this.axiosInstance.get(`/Xslt/RuleSets`, { params: { dataStructureId } })).data;
+    return (await this.http.get(`/Xslt/RuleSets`, { params: { dataStructureId } })).data;
   }
 
   async persistChanges(schemaItemId: string): Promise<void> {
-    await this.axiosInstance.post(`/Editor/PersistChanges`, {
+    await this.http.post(`/Editor/PersistChanges`, {
       schemaItemId,
     });
   }
 
   async persistSectionEditorChanges(schemaItemId: string): Promise<void> {
-    await this.axiosInstance.post(`/SectionEditor/Save`, {
+    await this.http.post(`/SectionEditor/Save`, {
       schemaItemId,
     });
   }
@@ -195,7 +172,7 @@ export class ArchitectApi implements IArchitectApi {
     changes: IPropertyChange[],
   ): Promise<IUpdatePropertiesResult> {
     return (
-      await this.axiosInstance.post(`/PropertyEditor/Update`, {
+      await this.http.post(`/PropertyEditor/Update`, {
         schemaItemId,
         changes,
       })
@@ -203,12 +180,12 @@ export class ArchitectApi implements IArchitectApi {
   }
 
   async deleteSchemaItem(schemaItemId: string) {
-    await this.axiosInstance.post('/Model/DeleteSchemaItem', { schemaItemId: schemaItemId });
+    await this.http.post('/Model/DeleteSchemaItem', { schemaItemId: schemaItemId });
   }
 
   async getMenuItems(node: IApiTreeNode): Promise<IMenuItemInfo[]> {
     return (
-      await this.axiosInstance.get(`/Model/GetMenuItems`, {
+      await this.http.get(`/Model/GetMenuItems`, {
         params: {
           id: node.origamId,
           nodeText: node.nodeText,
@@ -219,12 +196,12 @@ export class ArchitectApi implements IArchitectApi {
   }
 
   async getOpenEditors(): Promise<IApiEditorData[]> {
-    return (await this.axiosInstance.get(`/Editor/GetOpenEditors`)).data;
+    return (await this.http.get(`/Editor/GetOpenEditors`)).data;
   }
 
   async createNode(node: IApiTreeNode, typeName: string): Promise<IApiEditorData> {
     return (
-      await this.axiosInstance.post('/Editor/CreateNode', {
+      await this.http.post('/Editor/CreateNode', {
         nodeId: node.origamId,
         newTypeName: typeName,
       })
@@ -237,7 +214,7 @@ export class ArchitectApi implements IArchitectApi {
     selectedDataSourceId: string;
     modelChanges: IModelChange[];
   }): Promise<ISectionEditorModel> {
-    return (await this.axiosInstance.post(`/SectionEditor/Update`, args)).data;
+    return (await this.http.post(`/SectionEditor/Update`, args)).data;
   }
 
   async createSectionEditorItem(args: {
@@ -248,14 +225,14 @@ export class ArchitectApi implements IArchitectApi {
     top: number;
     left: number;
   }): Promise<IApiControl> {
-    return (await this.axiosInstance.post('/SectionEditor/CreateItem', args)).data;
+    return (await this.http.post('/SectionEditor/CreateItem', args)).data;
   }
 
   async deleteSectionEditorItem(args: {
     schemaItemIds: string[];
     editorSchemaItemId: string;
   }): Promise<ISectionEditorModel> {
-    return (await this.axiosInstance.post('/SectionEditor/Delete', args)).data;
+    return (await this.http.post('/SectionEditor/Delete', args)).data;
   }
 
   async updateScreenEditor(args: {
@@ -264,7 +241,7 @@ export class ArchitectApi implements IArchitectApi {
     selectedDataSourceId: string;
     modelChanges: IModelChange[];
   }): Promise<IScreenEditorModel> {
-    return (await this.axiosInstance.post(`/ScreenEditor/Update`, args)).data;
+    return (await this.http.post(`/ScreenEditor/Update`, args)).data;
   }
 
   async createScreenEditorItem(args: {
@@ -274,14 +251,14 @@ export class ArchitectApi implements IArchitectApi {
     top: number;
     left: number;
   }): Promise<IScreenEditorItem> {
-    return (await this.axiosInstance.post('/ScreenEditor/CreateItem', args)).data;
+    return (await this.http.post('/ScreenEditor/CreateItem', args)).data;
   }
 
   async deleteScreenEditorItem(args: {
     schemaItemIds: string[];
     editorSchemaItemId: string;
   }): Promise<IScreenEditorModel> {
-    return (await this.axiosInstance.post('/ScreenEditor/Delete', args)).data;
+    return (await this.http.post('/ScreenEditor/Delete', args)).data;
   }
 
   async loadSections(
@@ -289,7 +266,7 @@ export class ArchitectApi implements IArchitectApi {
     sectionIds: string[],
   ): Promise<Record<string, IApiControl>> {
     return (
-      await this.axiosInstance.get(`/ScreenEditor/GetSections`, {
+      await this.http.get(`/ScreenEditor/GetSections`, {
         params: {
           sectionIds: sectionIds,
           editorSchemaItemId: editorSchemaItemId,
@@ -299,18 +276,18 @@ export class ArchitectApi implements IArchitectApi {
   }
 
   async setVersionCurrent(schemaItemId: string): Promise<void> {
-    await this.axiosInstance.post('/DeploymentScripts/SetVersionCurrent', {
+    await this.http.post('/DeploymentScripts/SetVersionCurrent', {
       schemaItemId: schemaItemId,
     });
   }
 
   async runUpdateScriptActivity(schemaItemId: string): Promise<void> {
-    await this.axiosInstance.post('/DeploymentScripts/Run', { schemaItemId: schemaItemId });
+    await this.http.post('/DeploymentScripts/Run', { schemaItemId: schemaItemId });
   }
 
   async fetchDeploymentScriptsList(platform: string | null): Promise<IDatabaseResultResponse> {
     return (
-      await this.axiosInstance.get('/DeploymentScriptsGenerator/List', {
+      await this.http.get('/DeploymentScriptsGenerator/List', {
         params: {
           platform,
         },
@@ -319,11 +296,11 @@ export class ArchitectApi implements IArchitectApi {
   }
 
   async addToDeployment(request: IAddToDeploymentRequest): Promise<void> {
-    await this.axiosInstance.post('/DeploymentScriptsGenerator/AddToDeployment', request);
+    await this.http.post('/DeploymentScriptsGenerator/AddToDeployment', request);
   }
 
   async addToModel(request: IAddToModelRequest): Promise<void> {
-    await this.axiosInstance.post('/DeploymentScriptsGenerator/AddToModel', request);
+    await this.http.post('/DeploymentScriptsGenerator/AddToModel', request);
   }
 }
 

--- a/architect-html/src/API/httpClient.ts
+++ b/architect-html/src/API/httpClient.ts
@@ -1,0 +1,119 @@
+/*
+Copyright 2005 - 2026 Advantage Solutions, s. r. o.
+
+This file is part of ORIGAM (http://www.origam.org).
+
+ORIGAM is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+ORIGAM is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export interface HttpResponse<T> {
+  data: T;
+  status: number;
+}
+
+export interface HttpRequestConfig {
+  params?: Record<string, unknown>;
+}
+
+export class HttpError extends Error {
+  code?: string;
+  status?: number;
+  response?: { data: any; status: number };
+}
+
+function buildUrl(url: string, params?: Record<string, unknown>): string {
+  if (!params) return url;
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) continue;
+        search.append(`${key}[]`, String(item));
+      }
+    } else {
+      search.append(key, String(value));
+    }
+  }
+  const query = search.toString();
+  if (!query) return url;
+  return url + (url.includes('?') ? '&' : '?') + query;
+}
+
+async function parseBody(response: Response): Promise<any> {
+  if (response.status === 204) return undefined;
+  const contentType = response.headers.get('content-type') ?? '';
+  const text = await response.text();
+  if (text === '') return undefined;
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+  return text;
+}
+
+export class HttpClient {
+  constructor(private onError: (error: HttpError) => void) {}
+
+  get<T = any>(url: string, config?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    return this.request<T>('GET', url, config);
+  }
+
+  post<T = any>(url: string, body?: unknown): Promise<HttpResponse<T>> {
+    return this.request<T>('POST', url, undefined, body);
+  }
+
+  private async request<T>(
+    method: 'GET' | 'POST',
+    url: string,
+    config?: HttpRequestConfig,
+    body?: unknown,
+  ): Promise<HttpResponse<T>> {
+    const finalUrl = buildUrl(url, config?.params);
+    const init: RequestInit = {
+      method,
+      credentials: 'same-origin',
+    };
+    if (body !== undefined) {
+      init.headers = { 'Content-Type': 'application/json' };
+      init.body = JSON.stringify(body);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(finalUrl, init);
+    } catch (e: any) {
+      if (e?.name === 'AbortError') throw e;
+      const err = new HttpError(e?.message ?? 'Network Error');
+      err.code = 'ERR_NETWORK';
+      this.onError(err);
+      throw err;
+    }
+
+    const data = await parseBody(response);
+
+    if (!response.ok) {
+      const err = new HttpError(`Request failed with status ${response.status}`);
+      err.status = response.status;
+      err.response = { data, status: response.status };
+      this.onError(err);
+      throw err;
+    }
+
+    return { data: data as T, status: response.status };
+  }
+}

--- a/architect-html/src/errorHandling/handleError.tsx
+++ b/architect-html/src/errorHandling/handleError.tsx
@@ -24,7 +24,7 @@ const HANDLED = Symbol('_$ErrorHandled');
 
 export function handleError(controller: ErrorDialogController) {
   return function* handleError(error: any) {
-    if (error.code === 'ERR_NETWORK' && error.name === 'AxiosError') {
+    if (error.code === 'ERR_NETWORK') {
       yield* controller.pushError('Network Unavailable');
       return;
     }

--- a/architect-html/src/stores/TranslationsStore.tsx
+++ b/architect-html/src/stores/TranslationsStore.tsx
@@ -18,7 +18,6 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { getLocaleFromCookie, setLocaleToCookie } from '@utils/cookie';
-import axios from 'axios';
 import { observable } from 'mobx';
 
 const debugShowTranslations = window.localStorage.getItem('debugShowTranslations') === 'true';
@@ -37,8 +36,10 @@ export class TranslationsStore {
 
   async translationsInit(locale: string) {
     try {
-      const result = await axios.get(`locale/localization_${locale}.json`, {});
-      this.translations = result.data;
+      const response = await fetch(`locale/localization_${locale}.json`);
+      if (response.ok) {
+        this.translations = await response.json();
+      }
     } catch (error: any) {
       console.error(error);
     }

--- a/architect-html/yarn.lock
+++ b/architect-html/yarn.lock
@@ -1762,7 +1762,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.57.1"
     "@typescript-eslint/parser": "npm:^8.58.2"
     "@vitejs/plugin-react": "npm:^6.0.0"
-    axios: "npm:^1.13.6"
     classnames: "npm:^2.5.1"
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.8"
@@ -1952,17 +1951,6 @@ __metadata:
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^1.1.0"
   checksum: 10c0/abf468c34f2d145f3dc7dbc0f1be67e520630624307bda69a41bbe8d386bd672d87b4405c4ee77f9ff54b235ab02f96a9968fb00e75b13ce64706e352a3068fd
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.13.6":
-  version: 1.13.6
-  resolution: "axios@npm:1.13.6"
-  dependencies:
-    follow-redirects: "npm:^1.15.11"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/51fb5af055c3b85662fa97df17d986ae2c37d13bf86d50b6bb36b6b3a2dec6966a1d3a14ab3774b71707b155ae3597ed9b7babdf1a1a863d1a31840cb8e7ec71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace axios with a small fetch-based HttpClient wrapper that preserves the {data, status} response shape and ERR_NETWORK error code used by the existing error handling.