### PR TITLE
DEV: Remove obsolete certificate generation instructions

### DIFF
--- a/backend/Origam.Server/CertificateGeneration.txt
+++ b/backend/Origam.Server/CertificateGeneration.txt
@@ -1,8 +1,0 @@
-To generate certificate for JWT signing/verification
-
-"C:\Program Files\Git\usr\bin\openssl.exe" req -newkey rsa:2048 -nodes -keyout serverCore.key -x509 -days 365 -out serverCore.cer
-
-"C:\Program Files\Git\usr\bin\openssl.exe"   pkcs12 -export -in serverCore.cer -inkey serverCore.key -out serverCore.pfx
-
-Public key:
-"C:\Program Files\Git\usr\bin\openssl.exe" x509 -inform PEM -in serverCore.cer -outform PEM -pubkey -noout > public.key


### PR DESCRIPTION
* Deletes the outdated `CertificateGeneration.txt` file as it is no longer relevant to the current backend configuration.