### PR TITLE
DEV: Manual upgrade to Typescript6 in /architect-html

### DIFF
--- a/architect-html/package.json
+++ b/architect-html/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "prettier": "^3.8.3",
     "sass": "^1.99.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.0.9",
     "vite-plugin-mkcert": "^2.0.0",
     "vite-tsconfig-paths": "^6.1.1"

--- a/architect-html/src/components/editors/gridEditor/EditorProperty.ts
+++ b/architect-html/src/components/editors/gridEditor/EditorProperty.ts
@@ -24,7 +24,7 @@ import {
   IPropertyChange,
   IPropertyUpdate,
   PropertyType,
-} from 'src/API/IArchitectApi';
+} from '@api/IArchitectApi';
 
 export class EditorProperty implements IApiEditorProperty {
   name: string;

--- a/architect-html/src/components/editors/propertyEditor/IPropertyManager.tsx
+++ b/architect-html/src/components/editors/propertyEditor/IPropertyManager.tsx
@@ -17,8 +17,8 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { IUpdatePropertiesResult } from 'src/API/IArchitectApi';
-import { EditorProperty } from 'src/components/editors/gridEditor/EditorProperty';
+import { IUpdatePropertiesResult } from '@api/IArchitectApi';
+import { EditorProperty } from '@editors/gridEditor/EditorProperty';
 
 export interface IPropertyManager {
   onPropertyUpdated(

--- a/architect-html/src/components/packages/PackagesState.ts
+++ b/architect-html/src/components/packages/PackagesState.ts
@@ -18,11 +18,11 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { observable } from 'mobx';
-import { IArchitectApi, IPackage, IPackagesInfo } from 'src/API/IArchitectApi';
-import { ModelTreeState } from 'src/components/modelTree/ModelTreeState';
-import { TabViewState } from 'src/components/tabView/TabViewState';
-import { ProgressBarState } from 'src/components/topBar/ProgressBarState';
-import { UIState } from 'src/stores/UiState';
+import { IArchitectApi, IPackage, IPackagesInfo } from '@api/IArchitectApi';
+import { ModelTreeState } from '@components/modelTree/ModelTreeState';
+import { TabViewState } from '@components/tabView/TabViewState';
+import { ProgressBarState } from '@components/topBar/ProgressBarState';
+import { UIState } from '@stores/UiState';
 
 export class PackagesState {
   @observable.shallow accessor packages: IPackage[] = [];

--- a/architect-html/src/vite-env.d.ts
+++ b/architect-html/src/vite-env.d.ts
@@ -16,3 +16,5 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
+
+/// <reference types="vite/client" />

--- a/architect-html/tsconfig.app.json
+++ b/architect-html/tsconfig.app.json
@@ -5,6 +5,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node", "vite/client"],
     "module": "ESNext",
     "skipLibCheck": true,
 
@@ -24,17 +25,16 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@api/*": ["src/API/*"],
-      "@dialogs/*": ["src/dialog/*"],
-      "@errors/*": ["src/errorHandling/*"],
-      "@stores/*": ["src/stores/*"],
-      "@utils/*": ["src/utils/*"],
-      "@components/*": ["src/components/*"],
-      "@editors/*": ["src/components/editors/*"],
-      "@modules/*": ["src/modules/*"]
+      "@/*": ["./src/*"],
+      "@api/*": ["./src/API/*"],
+      "@dialogs/*": ["./src/dialog/*"],
+      "@errors/*": ["./src/errorHandling/*"],
+      "@stores/*": ["./src/stores/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@components/*": ["./src/components/*"],
+      "@editors/*": ["./src/components/editors/*"],
+      "@modules/*": ["./src/modules/*"]
     },
     "allowSyntheticDefaultImports": true
   },

--- a/architect-html/yarn.lock
+++ b/architect-html/yarn.lock
@@ -1723,7 +1723,7 @@ __metadata:
     react-icons: "npm:^5.6.0"
     react-inlinesvg: "npm:^4.3.0"
     sass: "npm:^1.99.0"
-    typescript: "npm:^5.9.3"
+    typescript: "npm:^6.0.3"
     vite: "npm:^8.0.9"
     vite-plugin-mkcert: "npm:^2.0.0"
     vite-tsconfig-paths: "npm:^6.1.1"
@@ -5281,23 +5281,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Upgrade TypeScript to version 6.0.3.
- Fix path alias resolution in tsconfig.app.json by using relative paths.
- Migrate absolute "src/*" imports to use defined path aliases.
- Add vite/client type references to compiler options and environment definitions.