### PR TITLE
DEV: Origam Composer prevent project creation if folder already exists

### DIFF
--- a/backend/Origam.Composer/Commands/CreateCommand.cs
+++ b/backend/Origam.Composer/Commands/CreateCommand.cs
@@ -36,6 +36,15 @@ public class CreateCommand(
 {
     public override int Execute(CommandContext context, CreateCommandSettings settings)
     {
+        if (
+            Directory.Exists(settings.ProjectFolder)
+            && Directory.EnumerateFileSystemEntries(settings.ProjectFolder).Any()
+        )
+        {
+            visualService.PrintProjectAlreadyExists(settings.ProjectFolder);
+            return 0;
+        }
+
         GitIdentity gitIdentity = GitIdentityResolver(settings);
         ShowVisualBanner(settings: settings, gitIdentity: gitIdentity);
 

--- a/backend/Origam.Composer/Interfaces/Services/IVisualService.cs
+++ b/backend/Origam.Composer/Interfaces/Services/IVisualService.cs
@@ -45,4 +45,6 @@ public interface IVisualService
     void PrintProjectCreateTasks(List<IBuilderTask> tasks);
 
     void PrintBye();
+
+    void PrintProjectAlreadyExists(string folder);
 }

--- a/backend/Origam.Composer/Services/VisualService.cs
+++ b/backend/Origam.Composer/Services/VisualService.cs
@@ -169,4 +169,20 @@ public class VisualService : IVisualService
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine(Strings.All_steps_completed);
     }
+
+    public void PrintProjectAlreadyExists(string folder)
+    {
+        var panel = new Panel(
+            new Markup($"[bold]{folder.EscapeMarkup()}[/]\n\nNothing to do, Composer will exit.")
+        )
+        {
+            Header = new PanelHeader("[yellow] Project already exists [/]"),
+            Border = BoxBorder.Rounded,
+            BorderStyle = new Style(foreground: Color.Yellow),
+            Padding = new Padding(1, 0, 1, 0),
+        };
+        AnsiConsole.WriteLine();
+        AnsiConsole.Write(panel);
+        AnsiConsole.WriteLine();
+    }
 }


### PR DESCRIPTION
Add a check in CreateCommand to detect if the target project folder exists and is not empty. If so, display a styled message and exit early to avoid overwriting existing projects. Introduce PrintProjectAlreadyExists to IVisualService and implement it in VisualService for user feedback.