### PR TITLE
FIX: Datatype load value /architect-html

### DIFF
--- a/architect-html/src/API/IArchitectApi.ts
+++ b/architect-html/src/API/IArchitectApi.ts
@@ -303,7 +303,7 @@ export enum OrigamDataType {
 
 export interface IPropertyUpdate {
   propertyName: string;
-  value: any;
+  value: PropertyValue;
   errors: string[];
   dropDownValues: IDropDownValue[];
 }
@@ -355,6 +355,8 @@ export interface IPackage {
 
 export type PropertyType = 'boolean' | 'enum' | 'string' | 'integer' | 'float' | 'looukup';
 
+export type PropertyValue = boolean | number | string | string[] | null;
+
 export interface IDeploymentScriptsGeneratorEditorData {
   possibleDeploymentVersions: IDeploymentVersion[];
   currentDeploymentVersionId: string | null;
@@ -370,7 +372,7 @@ export interface IApiEditorProperty {
   name: string;
   controlPropertyId: string | null;
   type: PropertyType;
-  value: any;
+  value: PropertyValue;
   dropDownValues: IDropDownValue[];
   category: string | null;
   description: string;

--- a/architect-html/src/API/IArchitectApi.ts
+++ b/architect-html/src/API/IArchitectApi.ts
@@ -231,7 +231,7 @@ export interface IModelChange {
 export interface IPropertyChange {
   name: string;
   controlPropertyId: string | null;
-  value: string;
+  value: string | null;
 }
 
 export interface ISectionEditorModel {

--- a/architect-html/src/API/IArchitectApi.ts
+++ b/architect-html/src/API/IArchitectApi.ts
@@ -303,6 +303,7 @@ export enum OrigamDataType {
 
 export interface IPropertyUpdate {
   propertyName: string;
+  value: any;
   errors: string[];
   dropDownValues: IDropDownValue[];
 }

--- a/architect-html/src/components/editors/DeploymentScriptsEditor/DeploymentScriptsEditor.tsx
+++ b/architect-html/src/components/editors/DeploymentScriptsEditor/DeploymentScriptsEditor.tsx
@@ -61,7 +61,10 @@ const DeploymentScriptsEditor = ({ editorState }: { editorState: GridEditorState
                 />
                 <CodeEditor
                   defaultLanguage="sql"
-                  value={editorState.properties.find(x => x.name === 'CommandText')?.value ?? ''}
+                  value={(() => {
+                    const value = editorState.properties.find(x => x.name === 'CommandText')?.value;
+                    return typeof value === 'string' ? value : '';
+                  })()}
                   onChange={text => handleInputChange(text)}
                 />
               </div>

--- a/architect-html/src/components/editors/designerEditor/common/designerComponents/Component.tsx
+++ b/architect-html/src/components/editors/designerEditor/common/designerComponents/Component.tsx
@@ -50,7 +50,7 @@ export class Component {
   }
 
   get relativeLeft(): number {
-    return this.getProperty('Left')!.value;
+    return this.getProperty('Left')!.value as number;
   }
 
   set relativeLeft(value: number) {
@@ -58,7 +58,7 @@ export class Component {
   }
 
   get relativeTop(): number {
-    return this.getProperty('Top')!.value;
+    return this.getProperty('Top')!.value as number;
   }
 
   set relativeTop(value: number) {
@@ -101,7 +101,7 @@ export class Component {
   }
 
   get width(): number {
-    return this.getProperty('Width')!.value;
+    return this.getProperty('Width')!.value as number;
   }
 
   set width(value: number) {
@@ -109,7 +109,7 @@ export class Component {
   }
 
   get height(): number {
-    return this.getProperty('Height')!.value;
+    return this.getProperty('Height')!.value as number;
   }
 
   set height(value: number) {
@@ -117,7 +117,7 @@ export class Component {
   }
 
   get labelWidth(): number {
-    return this.getProperty('CaptionLength')!.value;
+    return this.getProperty('CaptionLength')!.value as number;
   }
 
   set labelWidth(value: number) {

--- a/architect-html/src/components/editors/designerEditor/common/designerComponents/SplitPanel.tsx
+++ b/architect-html/src/components/editors/designerEditor/common/designerComponents/SplitPanel.tsx
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { IApiEditorProperty } from '@api/IArchitectApi';
+import { IApiEditorProperty, PropertyValue } from '@api/IArchitectApi';
 import { IComponentData } from '@editors/designerEditor/common/ComponentType';
 import { Component } from '@editors/designerEditor/common/designerComponents/Component';
 import S from '@editors/designerEditor/common/designerComponents/Components.module.scss';
@@ -167,7 +167,7 @@ class OrientationProperty extends EditorProperty {
     return super.value;
   }
 
-  set value(value: any) {
+  set value(value: PropertyValue) {
     super.value = value;
     this.splitPanel.update();
   }

--- a/architect-html/src/components/editors/gridEditor/EditorProperty.ts
+++ b/architect-html/src/components/editors/gridEditor/EditorProperty.ts
@@ -73,6 +73,7 @@ export class EditorProperty implements IApiEditorProperty {
     }
     this.errors = propertyUpdate.errors ?? [];
     this.dropDownValues = propertyUpdate.dropDownValues;
+    this.value = propertyUpdate.value;
     if (
       this.type === 'looukup' &&
       this._value != null &&

--- a/architect-html/src/components/editors/gridEditor/EditorProperty.ts
+++ b/architect-html/src/components/editors/gridEditor/EditorProperty.ts
@@ -24,12 +24,13 @@ import {
   IPropertyChange,
   IPropertyUpdate,
   PropertyType,
+  PropertyValue,
 } from '@api/IArchitectApi';
 
 export class EditorProperty implements IApiEditorProperty {
   name: string;
   type: PropertyType;
-  @observable protected accessor _value: any;
+  @observable protected accessor _value: PropertyValue;
   @observable.shallow accessor dropDownValues: IDropDownValue[];
   category: string | null;
   description: string;
@@ -37,11 +38,11 @@ export class EditorProperty implements IApiEditorProperty {
   readOnly: boolean;
   @observable accessor errors: string[];
 
-  get value(): any {
+  get value(): PropertyValue {
     return this._value;
   }
 
-  set value(value: any) {
+  set value(value: PropertyValue) {
     if (this.type === 'looukup' && value === '') {
       this._value = null;
     } else {

--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -51,7 +51,8 @@ export class GridEditorState implements IEditorState, IPropertyManager {
   }
 
   get label() {
-    return this.properties.find(x => x.name === 'Name')?.value || '';
+    const nameValue = this.properties.find(x => x.name === 'Name')?.value;
+    return typeof nameValue === 'string' ? nameValue : '';
   }
 
   *save(): Generator<Promise<any>, void, any> {

--- a/architect-html/src/components/editors/gridEditor/XsltEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/XsltEditorState.ts
@@ -62,9 +62,10 @@ export class XsltEditorState implements ITabViewState, IEditorState, IPropertyMa
   private readonly transformPropertyName: string;
 
   get xsl(): string {
-    return (
-      this.gridEditorState.properties.find(x => x.name === this.transformPropertyName)?.value ?? ''
-    );
+    const value = this.gridEditorState.properties.find(
+      x => x.name === this.transformPropertyName,
+    )?.value;
+    return typeof value === 'string' ? value : '';
   }
 
   constructor(
@@ -84,7 +85,8 @@ export class XsltEditorState implements ITabViewState, IEditorState, IPropertyMa
     this.nameProperty = properties?.find(prop => prop.name === 'Name');
     this.targetStructureProperty = properties?.find(prop => prop.name === 'Structure');
     if (this.targetStructureProperty) {
-      this.targetDataStructureId = this.targetStructureProperty.value;
+      const value = this.targetStructureProperty.value;
+      this.targetDataStructureId = typeof value === 'string' ? value : undefined;
     }
 
     if (properties?.find(x => x.name === 'TextStore')) {

--- a/architect-html/src/components/editors/propertyEditor/IPropertyManager.tsx
+++ b/architect-html/src/components/editors/propertyEditor/IPropertyManager.tsx
@@ -17,12 +17,12 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { IUpdatePropertiesResult } from '@api/IArchitectApi';
+import { IUpdatePropertiesResult, PropertyValue } from '@api/IArchitectApi';
 import { EditorProperty } from '@editors/gridEditor/EditorProperty';
 
 export interface IPropertyManager {
   onPropertyUpdated(
     property: EditorProperty,
-    value: any,
+    value: PropertyValue,
   ): Generator<Promise<IUpdatePropertiesResult>, void, IUpdatePropertiesResult>;
 }

--- a/architect-html/src/components/editors/propertyEditor/SinglePropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/SinglePropertyEditor.tsx
@@ -18,6 +18,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { RootStoreContext } from '@/main.tsx';
+import { PropertyValue } from '@api/IArchitectApi';
 import { EditorProperty } from '@editors/gridEditor/EditorProperty.ts';
 import { IPropertyManager } from '@editors/propertyEditor/IPropertyManager.tsx';
 import { NumericPropertyInput } from '@editors/propertyEditor/NumericPropertyInput.tsx';
@@ -37,10 +38,11 @@ const SinglePropertyEditor = observer(
       }
     };
 
-    const onValueChange = (property: EditorProperty, value: any) => {
+    const onValueChange = (property: EditorProperty, value: PropertyValue) => {
       runInFlowWithHandler(rootStore.errorDialogController)({
         generator: function* () {
-          const parsedValue = property.type === 'enum' ? parseInt(value) : value;
+          const parsedValue =
+            property.type === 'enum' && typeof value === 'string' ? parseInt(value) : value;
           yield* props.propertyManager.onPropertyUpdated(property, parsedValue);
         },
       });
@@ -71,7 +73,7 @@ const SinglePropertyEditor = observer(
           <div className={S.checkboxContainer}>
             <input
               type="checkbox"
-              checked={property.value}
+              checked={property.value as boolean}
               onChange={e => onValueChange(property, e.target.checked)}
               disabled={property.readOnly}
               className={S.checkbox}
@@ -113,7 +115,7 @@ const SinglePropertyEditor = observer(
           <input
             type="text"
             disabled={property.readOnly}
-            value={property.value != null ? property.value : undefined}
+            value={property.value != null ? String(property.value) : undefined}
             onChange={e => onValueChange(property, e.target.value)}
             title={property.value != null ? property.value.toString() : ''}
           />

--- a/architect-html/src/components/editors/propertyEditor/SinglePropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/SinglePropertyEditor.tsx
@@ -54,10 +54,7 @@ const SinglePropertyEditor = observer(
             : (property.value ?? '');
         return (
           <div className={S.selectWrapper}>
-            <select
-              value={selectedValue}
-              onChange={e => onValueChange(property, e.target.value)}
-            >
+            <select value={selectedValue} onChange={e => onValueChange(property, e.target.value)}>
               {property.dropDownValues.map(x => (
                 <option key={x.value + x.name} value={x.value}>
                   {x.name}

--- a/architect-html/src/components/editors/propertyEditor/SinglePropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/SinglePropertyEditor.tsx
@@ -48,10 +48,14 @@ const SinglePropertyEditor = observer(
 
     const renderControl = (property: EditorProperty) => {
       if (property.type === 'enum' || property.type === 'looukup') {
+        const selectedValue =
+          property.type === 'enum'
+            ? (property.dropDownValues.find(x => x.name === property.value)?.value ?? '')
+            : (property.value ?? '');
         return (
           <div className={S.selectWrapper}>
             <select
-              value={property.value ?? ''}
+              value={selectedValue}
               onChange={e => onValueChange(property, e.target.value)}
             >
               {property.dropDownValues.map(x => (
@@ -82,11 +86,6 @@ const SinglePropertyEditor = observer(
       if (property.type === 'integer' || property.type === 'float') {
         return (
           <div className={S.inputWithCopyButton}>
-            <NumericPropertyInput
-              property={property}
-              type={property.type}
-              onChange={value => onValueChange(property, value)}
-            />
             <button
               type="button"
               className={S.copyButton}
@@ -95,6 +94,11 @@ const SinglePropertyEditor = observer(
             >
               <VscCopy />
             </button>
+            <NumericPropertyInput
+              property={property}
+              type={property.type}
+              onChange={value => onValueChange(property, value)}
+            />
           </div>
         );
       }

--- a/backend/Origam.Architect.Server/Controllers/PropertyEditorController.cs
+++ b/backend/Origam.Architect.Server/Controllers/PropertyEditorController.cs
@@ -49,6 +49,7 @@ public class PropertyEditorController(
                 return new PropertyUpdate
                 {
                     PropertyName = editorProperty.Name,
+                    Value = editorProperty.Value,
                     Errors = propertyService.GetRuleErrors(property, editor.Item),
                     DropDownValues = editorProperty.DropDownValues ?? Array.Empty<DropDownValue>(),
                 };

--- a/backend/Origam.Architect.Server/ReturnModels/RuleErrors.cs
+++ b/backend/Origam.Architect.Server/ReturnModels/RuleErrors.cs
@@ -24,6 +24,7 @@ namespace Origam.Architect.Server.ReturnModels;
 public class PropertyUpdate
 {
     public string PropertyName { get; set; }
+    public object Value { get; set; }
     public List<string> Errors { get; set; }
     public DropDownValue[] DropDownValues { get; set; }
 }


### PR DESCRIPTION
* PropertyEditorController now populates Value from editorProperty.Value
* EditorProperty.update() applies the incoming propertyUpdate.value to this.value, so server-normalized values flow back into the UI
* In SinglePropertyEditor, the <select>'s selected value for enum is resolved via dropDownValues.find(x => x.name === property.value)?.value instead of using property.value directly; looukup keeps the previous behavior
* Reordered the copy button to render before NumericPropertyInput (layout only, matches the text-input branch)