### PR TITLE
UX: Show version in header /architect-html

### DIFF
--- a/architect-html/src/components/logo/Logo.module.scss
+++ b/architect-html/src/components/logo/Logo.module.scss
@@ -26,13 +26,20 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
     width: auto;
   }
 
-  > span {
+  > .label {
     position: absolute;
     bottom: -6px;
     right: 0;
-    font-size: 12px;
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
     color: var(--brand);
+    font-size: 12px;
     line-height: 1;
     font-weight: 400;
+  }
+
+  .version {
+    text-transform: uppercase;
   }
 }

--- a/architect-html/src/components/logo/Logo.tsx
+++ b/architect-html/src/components/logo/Logo.tsx
@@ -23,7 +23,10 @@ const Logo = () => {
   return (
     <div className={S.root}>
       <img src="/ORIGAM-logo.svg" alt="ORIGAM" />
-      <span>Architect</span>
+      <div className={S.label}>
+        <span className={S.product}>Architect</span>
+        <span className={S.version}>{__ORIGAM_ARCHITECT_HTML_VERSION__}</span>
+      </div>
     </div>
   );
 };

--- a/architect-html/src/vite-env.d.ts
+++ b/architect-html/src/vite-env.d.ts
@@ -18,3 +18,5 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
 /// <reference types="vite/client" />
+
+declare const __ORIGAM_ARCHITECT_HTML_VERSION__: string;

--- a/architect-html/vite.config.ts
+++ b/architect-html/vite.config.ts
@@ -5,6 +5,11 @@ import { defineConfig } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
 
 export default defineConfig({
+  define: {
+    __ORIGAM_ARCHITECT_HTML_VERSION__: JSON.stringify(
+      process.env.VITE_ORIGAM_ARCHITECT_HTML_VERSION ?? 'dev',
+    ),
+  },
   plugins: [
     react(),
     babel({

--- a/build/build-monorepo.yaml
+++ b/build/build-monorepo.yaml
@@ -308,6 +308,8 @@ jobs:
         yarn build
        workingDirectory: $(Agent.BuildDirectory)\s\origam\architect-html\
        displayName: 'origam-architect-client yarn build'
+       env:
+         VITE_ORIGAM_ARCHITECT_HTML_VERSION: $(VERSION_NUMBER)
      - task: PublishBuildArtifacts@1
        displayName: 'Publish artifact: origam-architect-client'
        inputs:


### PR DESCRIPTION
* Render version label next to "Architect" wordmark in the logo
* Localhost development has "DEV" mark (as we can see it in the screenshot)
* Inject build version via Vite `define` from `VITE_ORIGAM_ARCHITECT_HTML_VERSION`, falling back to `dev` locally
* Pass `VERSION_NUMBER` to the architect-html `yarn build` step in the monorepo pipeline
* Restyle the logo label as a flex row and uppercase the version

https://support.advantages.cz/t/html-architect-pridat-info-o-verzi/4161/4

<img width="954" height="528" alt="image" src="https://github.com/user-attachments/assets/91ffbea8-bc6e-41df-8762-91cf97042a55" />