### PR TITLE
FIX: Save button with empty required fields /backend

### DIFF
--- a/backend/Origam.Architect.Server/Controllers/EditorController.cs
+++ b/backend/Origam.Architect.Server/Controllers/EditorController.cs
@@ -112,9 +112,11 @@ public class EditorController(
     {
         object data = treeNode.DefaultEditor switch
         {
-            EditorSubType.GridEditor => propertyService.GetEditorProperties(item),
-            EditorSubType.DeploymentScriptsEditor => propertyService.GetEditorProperties(item),
-            EditorSubType.XsltEditor => propertyService.GetEditorProperties(item),
+            EditorSubType.GridEditor => propertyService.GetEditorPropertiesWithErrors(item),
+            EditorSubType.DeploymentScriptsEditor => propertyService.GetEditorPropertiesWithErrors(
+                item
+            ),
+            EditorSubType.XsltEditor => propertyService.GetEditorPropertiesWithErrors(item),
             EditorSubType.ScreenSectionEditor => sectionService.GetSectionEditorData(item),
             EditorSubType.ScreenEditor => sectionService.GetScreenEditorData(item),
             _ => null,


### PR DESCRIPTION
* Populate validation errors when opening a freshly created schema item so the Save button stays disabled until required fields (e.g. Name, MappedColumnName) are filled
* Switch grid, deployment-scripts and XSLT editors in `GetEditorProperties` to `GetEditorPropertiesWithErrors`

https://support.advantages.cz/t/html-architect-chybne-fungovani-tlacitka-save-v-standardnim-editoru/4164/5