### PR TITLE
FEATURE: Show element type in property editor title

### DIFF
--- a/architect-html/public/locale/localization_en-US.json
+++ b/architect-html/public/locale/localization_en-US.json
@@ -28,6 +28,7 @@
   "tab_header_close_all": "Close All",
   "tab_header_close_all_but_this": "Close All But This",
   "grid_editor_title": "Editing: {0}",
+  "grid_editor_title_full": "{0}: {1}",
   "documentation_editor_title": "Documentation: {0}",
   "screen_section_editor_title": "Screen Section Editor: {0}",
   "screen_editor_title": "Screen Editor: {0}",

--- a/architect-html/src/API/IArchitectApi.ts
+++ b/architect-html/src/API/IArchitectApi.ts
@@ -340,6 +340,7 @@ export interface IApiTreeNode extends INodeLoadData {
   children?: IApiTreeNode[];
   iconUrl?: string;
   itemType?: string;
+  itemTypeName?: string;
   isCurrentVersion?: boolean;
 }
 
@@ -405,4 +406,5 @@ export interface IApiEditorNode {
   origamId: string;
   nodeText: string;
   editorType: EditorSubType;
+  itemTypeName?: string;
 }

--- a/architect-html/src/components/editors/getEditorContainer.tsx
+++ b/architect-html/src/components/editors/getEditorContainer.tsx
@@ -108,9 +108,7 @@ export function getEditorContainer(args: {
       isDirty,
       architectApi,
     );
-    const editorComponent = (
-      <GridEditor editorState={editorState} title={editorState.title} />
-    );
+    const editorComponent = <GridEditor editorState={editorState} title={editorState.title} />;
     return new EditorContainer(editorState, editorComponent);
   }
 

--- a/architect-html/src/components/editors/getEditorContainer.tsx
+++ b/architect-html/src/components/editors/getEditorContainer.tsx
@@ -109,10 +109,7 @@ export function getEditorContainer(args: {
       architectApi,
     );
     const editorComponent = (
-      <GridEditor
-        editorState={editorState}
-        title={T('Editing: {0}', 'grid_editor_title', editorState.label)}
-      />
+      <GridEditor editorState={editorState} title={editorState.title} />
     );
     return new EditorContainer(editorState, editorComponent);
   }

--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { T } from '@/main';
 import { IArchitectApi, IUpdatePropertiesResult } from '@api/IArchitectApi';
 import { IEditorNode } from '@components/editorTabView/EditorTabViewState';
 import { IEditorState } from '@components/editorTabView/IEditorState';
@@ -53,6 +54,18 @@ export class GridEditorState implements IEditorState, IPropertyManager {
   get label() {
     const nameValue = this.properties.find(x => x.name === 'Name')?.value;
     return typeof nameValue === 'string' ? nameValue : '';
+  }
+
+  get title(): string {
+    const typeName = this.editorNode.itemTypeName;
+    const label = this.label;
+    if (typeName && label) {
+      return T('{0}: {1}', 'grid_editor_title_full', typeName, label);
+    }
+    if (typeName) {
+      return typeName;
+    }
+    return T('Editing: {0}', 'grid_editor_title', label);
   }
 
   *save(): Generator<Promise<any>, void, any> {

--- a/architect-html/src/components/modelTree/EditorData.ts
+++ b/architect-html/src/components/modelTree/EditorData.ts
@@ -37,6 +37,7 @@ export class EditorNode implements IEditorNode {
   origamId: string;
   nodeText: string;
   editorType: EditorSubType;
+  itemTypeName?: string;
   parent: TreeNode | null = null;
 
   constructor(node: IApiEditorNode, parent: TreeNode | null) {
@@ -44,6 +45,7 @@ export class EditorNode implements IEditorNode {
     this.origamId = node.origamId;
     this.nodeText = node.nodeText;
     this.editorType = node.editorType;
+    this.itemTypeName = node.itemTypeName;
     this.parent = parent;
   }
 }

--- a/architect-html/src/components/modelTree/TreeNode.ts
+++ b/architect-html/src/components/modelTree/TreeNode.ts
@@ -46,6 +46,7 @@ export class TreeNode implements IEditorNode {
     this.childrenIds = apiNode.childrenIds;
     this.iconUrl = apiNode.iconUrl;
     this.itemType = apiNode.itemType;
+    this.itemTypeName = apiNode.itemTypeName;
     this.isCurrentVersion = apiNode.isCurrentVersion;
     this.children = apiNode.children
       ? apiNode.children.map(child => new TreeNode(child, this.rootStore, this))
@@ -64,6 +65,7 @@ export class TreeNode implements IEditorNode {
   childrenIds: string[];
   iconUrl?: string;
   itemType?: string;
+  itemTypeName?: string;
   isCurrentVersion?: boolean;
 
   @observable accessor isLoading: boolean = false;

--- a/backend/Origam.Architect.Server/ReturnModels/TreeNode.cs
+++ b/backend/Origam.Architect.Server/ReturnModels/TreeNode.cs
@@ -36,6 +36,7 @@ public class TreeNode
     public List<TreeNode> Children { get; set; }
     public EditorSubType? DefaultEditor { get; set; }
     public string ItemType { get; set; }
+    public string ItemTypeName { get; set; }
     public bool? IsCurrentVersion { get; set; }
 
     public static string ToTreeNodeId(IBrowserNode2 node)
@@ -63,6 +64,7 @@ public class TreeNodeFactory
             DefaultEditor = GetEditorType(node),
             IconUrl = GetIcon(node),
             ItemType = node.GetType().FullName,
+            ItemTypeName = node.GetType().SchemaItemDescription()?.Name,
             IsCurrentVersion = (node as Schema.DeploymentModel.DeploymentVersion)?.IsCurrentVersion,
         };
     }


### PR DESCRIPTION
* Expose `ItemTypeName` (from `SchemaItemDescription`) on the backend tree-node DTO.
* Propagate `itemTypeName` through API contracts and tree/editor models on the frontend.
* Build the Grid editor title as `Type: Label`, with fallbacks when the type or label is missing.
* Add `grid_editor_title_full` localization key (en-US).

https://support.advantages.cz/t/newarch-nazev-elementu-v-actionpanel/4546

<img width="1006" height="420" alt="image" src="https://github.com/user-attachments/assets/2213db8a-f7c6-4968-af94-cacd44b92ca5" />
