### PR TITLE
FEATURE: Close all open tabs when switching packages in HTML Architect

### DIFF
--- a/architect-html/src/API/ArchitectApi.ts
+++ b/architect-html/src/API/ArchitectApi.ts
@@ -113,6 +113,10 @@ export class ArchitectApi implements IArchitectApi {
     await this.http.post('/Editor/CloseEditor', { editorId: editorId });
   }
 
+  async closeAllEditors() {
+    await this.http.post('/Editor/CloseAllEditors', {});
+  }
+
   async openDocumentationEditor(schemaItemId: string): Promise<IApiEditorData> {
     return (await this.http.post('/Documentation/OpenEditor', { schemaItemId: schemaItemId })).data;
   }

--- a/architect-html/src/API/IArchitectApi.ts
+++ b/architect-html/src/API/IArchitectApi.ts
@@ -38,6 +38,8 @@ export interface IArchitectApi {
 
   closeEditor(editorId: string): Promise<void>;
 
+  closeAllEditors(): Promise<void>;
+
   persistChanges(schemaItemId: string): Promise<void>;
 
   persistSectionEditorChanges(schemaItemId: string): Promise<void>;

--- a/architect-html/src/components/editorTabView/EditorTabViewState.ts
+++ b/architect-html/src/components/editorTabView/EditorTabViewState.ts
@@ -202,6 +202,40 @@ export class EditorTabViewState {
     }
   }
 
+  closeAllEditors() {
+    return function* (this: EditorTabViewState): Generator<Promise<any>, boolean, any> {
+      const dirtyEditors = this.editorsContainers.filter(editor => editor.state.isDirty);
+      if (dirtyEditors.length > 0) {
+        const saveChanges = yield askYesNoQuestion(
+          this.rootStore.dialogStack,
+          'Save changes',
+          dirtyEditors.length === 1
+            ? `Do you want to save ${dirtyEditors[0].state.label}?`
+            : `Do you want to save changes to ${dirtyEditors.length} open tabs?`,
+        );
+        switch (saveChanges) {
+          case YesNoResult.Cancel:
+            return false;
+          case YesNoResult.Yes:
+            for (const editor of dirtyEditors) {
+              yield* editor.state.save();
+            }
+            break;
+          case YesNoResult.No:
+            break;
+        }
+      }
+
+      for (const editor of this.editorsContainers) {
+        editor.state.dispose?.();
+      }
+      this.editorsContainers = [];
+      yield this.architectApi.closeAllEditors();
+      this.rootStore.uiState.setDsGeneratorState({ isOpen: false });
+      return true;
+    }.bind(this);
+  }
+
   closeEditor(editorId: string) {
     return function* (this: EditorTabViewState): Generator<Promise<any>, void, any> {
       if (this.activeEditorState?.isDirty) {

--- a/architect-html/src/components/packages/PackagesState.ts
+++ b/architect-html/src/components/packages/PackagesState.ts
@@ -19,6 +19,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 import { observable } from 'mobx';
 import { IArchitectApi, IPackage, IPackagesInfo } from '@api/IArchitectApi';
+import { EditorTabViewState } from '@components/editorTabView/EditorTabViewState';
 import { ModelTreeState } from '@components/modelTree/ModelTreeState';
 import { TabViewState } from '@components/tabView/TabViewState';
 import { ProgressBarState } from '@components/topBar/ProgressBarState';
@@ -33,6 +34,7 @@ export class PackagesState {
     private progressBarState: ProgressBarState,
     private sideBarTabViewState: TabViewState,
     private modelTreeState: ModelTreeState,
+    private editorTabViewState: EditorTabViewState,
     private uiState: UIState,
     private architectApi: IArchitectApi,
   ) {}
@@ -61,7 +63,14 @@ export class PackagesState {
   }
 
   setActivePackageClick(packageId: string) {
-    return function* (this: PackagesState) {
+    return function* (this: PackagesState): Generator<any, void, any> {
+      if (packageId === this.activePackageId) {
+        return;
+      }
+      const proceed: boolean = yield* this.editorTabViewState.closeAllEditors()();
+      if (!proceed) {
+        return;
+      }
       yield* this.setActivePackage(packageId)();
       if (this.activePackageChanged) {
         this.uiState.clearExpandedNodes();

--- a/architect-html/src/stores/RootStore.ts
+++ b/architect-html/src/stores/RootStore.ts
@@ -54,6 +54,7 @@ export class RootStore {
       this.progressBarState,
       this.sideBarTabViewState,
       this.modelTreeState,
+      this.editorTabViewState,
       this.uiState,
       this.architectApi,
     );

--- a/backend/Origam.Architect.Server/Controllers/EditorController.cs
+++ b/backend/Origam.Architect.Server/Controllers/EditorController.cs
@@ -130,6 +130,13 @@ public class EditorController(
         return Ok();
     }
 
+    [HttpPost("CloseAllEditors")]
+    public IActionResult CloseAllEditors()
+    {
+        editorService.CloseAllEditors();
+        return Ok();
+    }
+
     [HttpPost("PersistChanges")]
     public IActionResult PersistChanges([FromBody] PersistModel input)
     {

--- a/backend/Origam.Architect.Server/Services/EditorService.cs
+++ b/backend/Origam.Architect.Server/Services/EditorService.cs
@@ -201,6 +201,14 @@ public class EditorService(
         }
     }
 
+    public void CloseAllEditors()
+    {
+        foreach (EditorId editorId in editorSchemaItems.Keys.ToList())
+        {
+            CloseEditor(editorId);
+        }
+    }
+
     public EditorData ChangesToEditorData(ChangesModel input)
     {
         EditorData editor = OpenDefaultEditor(input.SchemaItemId);


### PR DESCRIPTION
Implemented a new feature to close all open editors when switching packages in HTML Architect

Frontend:
- Added `closeAllEditors` method to `ArchitectApi` for API communication.
- Updated `IArchitectApi` interface to include `closeAllEditors` and `persistChanges`.
- Introduced `closeAllEditors` generator in `EditorTabViewState` to handle user prompts, save changes, and clear editor states.
- Updated `PackagesState` to close all editors before switching active packages.
- Modified `RootStore` to inject `EditorTabViewState` into `PackagesState`.

Backend:
- Added `CloseAllEditors` endpoint in `EditorController` to handle requests.
- Implemented `CloseAllEditors` method in `EditorService` to close all open editors.