### PR TITLE
UX: Section title unification /architect-html

### DIFF
--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
@@ -41,7 +41,7 @@ const PropertyEditor = observer(
       <div className={cn(S.root, { [S.compact]: props.compact })}>
         {sortedCategories.map(category => (
           <div className={S.category} key={category}>
-            {!props.compact && <h4>{category ?? 'Misc'}</h4>}
+            {!props.compact && <h4>{(category ?? 'Misc').replace(/^\((.*)\)$/, '$1')}</h4>}
             {groupedProperties[category].map((property: EditorProperty) => (
               <div className={S.property} key={property.name}>
                 <div


### PR DESCRIPTION
* Strip wrapping parentheses from property grid category titles (`(Info)` → `Info`, `(Schema Item)` → `Schema Item`).
* Categories without parentheses (`Entity`, `Mapping`, …) are unchanged.
* Sort order is preserved — only the displayed label is stripped, the category key stays the same.
* Done in `PropertyEditor.tsx` only; backend `[Category(...)]` attributes are left intact because the legacy WinForms Architect still relies on them.