### PR TITLE
UX: Mark required fields /architect-html

### DIFF
--- a/architect-html/src/components/SaveButtonHOC/SaveButtonHOC.module.scss
+++ b/architect-html/src/components/SaveButtonHOC/SaveButtonHOC.module.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2005 - 2025 Advantage Solutions, s. r. o.
+Copyright 2005 - 2026 Advantage Solutions, s. r. o.
 
 This file is part of ORIGAM (http://www.origam.org).
 
@@ -17,17 +17,24 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
-export interface IValidationError {
-  propertyName: string;
-  error: string;
+.root {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-export interface IEditorState {
-  editorId: string;
-  label: string;
-  isActive: boolean;
-  isDirty: boolean;
-  validationErrors?: IValidationError[];
-  save(): Generator<Promise<any>, void, any>;
-  dispose?(): void;
+.missingFields {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: red;
+  font-size: 0.875rem;
+  max-width: 24rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  svg {
+    flex-shrink: 0;
+  }
 }

--- a/architect-html/src/components/SaveButtonHOC/SaveButtonHOC.tsx
+++ b/architect-html/src/components/SaveButtonHOC/SaveButtonHOC.tsx
@@ -19,10 +19,11 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 import { RootStoreContext, T } from '@/main';
 import Button from '@components/Button/Button';
+import S from '@/components/SaveButtonHOC/SaveButtonHOC.module.scss';
 import { runInFlowWithHandler } from '@errors/runInFlowWithHandler';
 import { observer } from 'mobx-react-lite';
 import { useContext } from 'react';
-import { VscSave } from 'react-icons/vsc';
+import { VscSave, VscWarning } from 'react-icons/vsc';
 
 const SaveButtonHOC = observer(() => {
   const rootStore = useContext(RootStoreContext);
@@ -49,14 +50,35 @@ const SaveButtonHOC = observer(() => {
     });
   };
 
+  const isDisabled = !activeEditor.isDirty;
+  const validationErrors = activeEditor.validationErrors ?? [];
+  const showMissing = isDisabled && validationErrors.length > 0;
+
   return (
-    <Button
-      type="primary"
-      title={T('Save', 'save_button_label')}
-      prefix={<VscSave />}
-      onClick={handleSave}
-      isDisabled={!activeEditor.isDirty}
-    />
+    <div className={S.root}>
+      {showMissing && (
+        <div
+          className={S.missingFields}
+          title={validationErrors.map(e => `${e.propertyName}: ${e.error}`).join('\n')}
+        >
+          <VscWarning />
+          <span>
+            {T(
+              'Required: {0}',
+              'save_required_fields',
+              validationErrors.map(e => e.propertyName).join(', '),
+            )}
+          </span>
+        </div>
+      )}
+      <Button
+        type="primary"
+        title={T('Save', 'save_button_label')}
+        prefix={<VscSave />}
+        onClick={handleSave}
+        isDisabled={isDisabled}
+      />
+    </div>
   );
 });
 

--- a/architect-html/src/components/SaveButtonHOC/SaveButtonHOC.tsx
+++ b/architect-html/src/components/SaveButtonHOC/SaveButtonHOC.tsx
@@ -63,11 +63,8 @@ const SaveButtonHOC = observer(() => {
         >
           <VscWarning />
           <span>
-            {T(
-              'Required: {0}',
-              'save_required_fields',
-              validationErrors.map(e => e.propertyName).join(', '),
-            )}
+            <strong>{T('Required:', 'save_required_fields_label')}</strong>{' '}
+            {validationErrors.map(e => e.propertyName).join(', ')}
           </span>
         </div>
       )}

--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -20,7 +20,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 import { T } from '@/main';
 import { IArchitectApi, IUpdatePropertiesResult } from '@api/IArchitectApi';
 import { IEditorNode } from '@components/editorTabView/EditorTabViewState';
-import { IEditorState } from '@components/editorTabView/IEditorState';
+import { IEditorState, IValidationError } from '@components/editorTabView/IEditorState';
 import { EditorProperty, toChanges } from '@editors/gridEditor/EditorProperty';
 import { IPropertyManager } from '@editors/propertyEditor/IPropertyManager';
 import { computed, observable } from 'mobx';
@@ -49,6 +49,13 @@ export class GridEditorState implements IEditorState, IPropertyManager {
       someHasError = someHasError || !!property.error;
     }
     return this._isDirty && !someHasError;
+  }
+
+  @computed
+  get validationErrors(): IValidationError[] {
+    return this.properties
+      .filter(p => p.error)
+      .map(p => ({ propertyName: p.name, error: p.error! }));
   }
 
   get label() {

--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.module.scss
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.module.scss
@@ -47,9 +47,18 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
       .propertyName {
         overflow-wrap: anywhere;
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
       }
 
       .errorProperty {
+        color: red;
+        font-weight: 700;
+      }
+
+      .errorIcon {
+        flex-shrink: 0;
         color: red;
       }
     }

--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
@@ -24,6 +24,7 @@ import SinglePropertyEditor from '@editors/propertyEditor/SinglePropertyEditor.t
 import { getSortedProperties } from '@editors/propertyEditor/utils';
 import cn from 'classnames';
 import { observer } from 'mobx-react-lite';
+import { VscWarning } from 'react-icons/vsc';
 
 const PropertyEditor = observer(
   (props: {
@@ -48,7 +49,8 @@ const PropertyEditor = observer(
                   title={property.error}
                   className={cn(S.propertyName, { [S.errorProperty]: property.error })}
                 >
-                  {property.name}
+                  {property.error && <VscWarning className={S.errorIcon} />}
+                  <span>{property.name}</span>
                 </div>
                 <SinglePropertyEditor
                   property={property}


### PR DESCRIPTION
* Property grid: invalid/required fields are now rendered **bold** with a red warning icon, not just colored text.
* Save button: when Save is disabled due to validation errors, the blocking properties are listed inline next to the button (with a tooltip showing the full error messages).
* Added optional `validationErrors` on `IEditorState`, implemented in `GridEditorState` from existing `EditorProperty.error` values — no backend changes required.
* Behavior unchanged when the editor is simply not dirty (no list is shown in that case).

<img width="973" height="629" alt="image" src="https://github.com/user-attachments/assets/7d1770d9-7427-463e-8903-5de28214db3a" />