### PR TITLE
UX: Auto-fill MappedObjectName from Name /architect-html

### DIFF
--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -87,16 +87,18 @@ export class GridEditorState implements IEditorState, IPropertyManager {
   ): Generator<Promise<IUpdatePropertiesResult>, void, IUpdatePropertiesResult> {
     if (property.name === 'Name') {
       const oldName = property.value;
-      const mappedObjectName = this.properties.find(p => p.name === 'MappedObjectName');
-      if (
-        mappedObjectName &&
-        !mappedObjectName.readOnly &&
-        (mappedObjectName.value === null ||
-          mappedObjectName.value === undefined ||
-          mappedObjectName.value === '' ||
-          mappedObjectName.value === oldName)
-      ) {
-        mappedObjectName.value = value;
+      for (const mappedName of ['MappedObjectName', 'MappedColumnName']) {
+        const mapped = this.properties.find(p => p.name === mappedName);
+        if (
+          mapped &&
+          !mapped.readOnly &&
+          (mapped.value === null ||
+            mapped.value === undefined ||
+            mapped.value === '' ||
+            mapped.value === oldName)
+        ) {
+          mapped.value = value;
+        }
       }
     }
     property.value = value;

--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -87,9 +87,7 @@ export class GridEditorState implements IEditorState, IPropertyManager {
   ): Generator<Promise<IUpdatePropertiesResult>, void, IUpdatePropertiesResult> {
     if (property.name === 'Name') {
       const oldName = property.value;
-      const mappedObjectName = this.properties.find(
-        p => p.name === 'MappedObjectName',
-      );
+      const mappedObjectName = this.properties.find(p => p.name === 'MappedObjectName');
       if (
         mappedObjectName &&
         !mappedObjectName.readOnly &&

--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -85,6 +85,22 @@ export class GridEditorState implements IEditorState, IPropertyManager {
     property: EditorProperty,
     value: any,
   ): Generator<Promise<IUpdatePropertiesResult>, void, IUpdatePropertiesResult> {
+    if (property.name === 'Name') {
+      const oldName = property.value;
+      const mappedObjectName = this.properties.find(
+        p => p.name === 'MappedObjectName',
+      );
+      if (
+        mappedObjectName &&
+        !mappedObjectName.readOnly &&
+        (mappedObjectName.value === null ||
+          mappedObjectName.value === undefined ||
+          mappedObjectName.value === '' ||
+          mappedObjectName.value === oldName)
+      ) {
+        mappedObjectName.value = value;
+      }
+    }
     property.value = value;
     const changes = toChanges(this.properties);
     const updateResult = (yield this.architectApi.updateProperties(


### PR DESCRIPTION
* Auto-populate `MappedObjectName` in the grid editor as the user types into `Name`
* Only override when `MappedObjectName` is empty or still matches the previous `Name` value
* Preserve manually entered `MappedObjectName` values
* Scope extended: Auto-fill to `MappedColumnName` for new database fields