### PR TITLE
SECURITY: Prevent exception details from error responses

### DIFF
--- a/backend/Origam.Server/Controller/BlobController.cs
+++ b/backend/Origam.Server/Controller/BlobController.cs
@@ -163,7 +163,11 @@ public class BlobController : AbstractController
         }
         catch (Exception ex)
         {
-            return StatusCode(statusCode: 500, ex);
+            log.LogError(ex, $"Error processing blob download request for token {token}");
+            return StatusCode(
+                statusCode: 500,
+                value: new { Message = localizer["ErrorBlobDownloadFailed"].ToString() }
+            );
         }
         finally
         {
@@ -256,7 +260,11 @@ public class BlobController : AbstractController
         }
         catch (Exception ex)
         {
-            return StatusCode(statusCode: 500, ex);
+            log.LogError(ex, $"Error processing blob upload request for token {token}");
+            return StatusCode(
+                statusCode: 500,
+                value: new { Message = localizer["ErrorBlobUploadFailed"].ToString() }
+            );
         }
         finally
         {

--- a/backend/Origam.Server/Controller/ChatController.cs
+++ b/backend/Origam.Server/Controller/ChatController.cs
@@ -25,6 +25,7 @@ using System.Data;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Origam.DA;
 using Origam.DA.Service;
@@ -44,6 +45,7 @@ namespace Origam.Server.Controller;
 public class ChatController : ControllerBase
 {
     private readonly ILogger<ChatController> log;
+    private readonly IStringLocalizer<SharedResources> localizer;
 
     private readonly Guid OrigamChatMessageDataStructureId = new Guid(
         "f9ec17ce-13fc-420c-88b0-3a793fae4001"
@@ -100,9 +102,10 @@ public class ChatController : ControllerBase
         "763e029f-b306-40bd-98f9-36f89297cfbf"
     );
 
-    public ChatController(ILogger<ChatController> log)
+    public ChatController(ILogger<ChatController> log, IStringLocalizer<SharedResources> localizer)
     {
         this.log = log;
+        this.localizer = localizer;
     }
 
     [HttpGet("chatrooms/{requestChatRoomId:guid}/messages")]
@@ -834,16 +837,22 @@ public class ChatController : ControllerBase
         catch (DBConcurrencyException ex)
         {
             log.LogError(ex, ex.Message);
-            return StatusCode(statusCode: 409, ex);
+            return StatusCode(
+                statusCode: 409,
+                new { Message = localizer["ObjectModified"].ToString() }
+            );
         }
         catch (Exception ex)
         {
             if (ex is IUserException)
             {
-                return StatusCode(statusCode: 420, ex);
+                return StatusCode(statusCode: 420, new { Message = ex.Message });
             }
             log.LogOrigamError(ex, ex.Message);
-            return StatusCode(statusCode: 500, ex);
+            return StatusCode(
+                statusCode: 500,
+                new { Message = localizer["UnknownError"].ToString() }
+            );
         }
     }
 }

--- a/backend/Origam.Server/Controller/ReportController.cs
+++ b/backend/Origam.Server/Controller/ReportController.cs
@@ -100,7 +100,14 @@ public class ReportController : AbstractController
         }
         catch (Exception ex)
         {
-            return StatusCode(statusCode: 500, ex);
+            log.LogError(
+                exception: ex,
+                message: $"Error processing report request for reportRequestId {reportRequestId}"
+            );
+            return StatusCode(
+                statusCode: 500,
+                value: new { Message = localizer["UnknownError"].ToString() }
+            );
         }
         finally
         {

--- a/backend/Origam.Server/Controller/WorkQueueController.cs
+++ b/backend/Origam.Server/Controller/WorkQueueController.cs
@@ -35,18 +35,11 @@ namespace Origam.Server.Controller;
 
 [Authorize(Policy = "InternalApi")]
 [ApiController]
-public class WorkQueueController : ControllerBase
+public class WorkQueueController(IStringLocalizer<SharedResources> localizer) : ControllerBase
 {
     private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
         System.Reflection.MethodBase.GetCurrentMethod().DeclaringType
     );
-
-    private readonly IStringLocalizer<SharedResources> localizer;
-
-    public WorkQueueController(IStringLocalizer<SharedResources> localizer)
-    {
-        this.localizer = localizer;
-    }
 
     [HttpPost]
     [Route("workQueue/{workQueueCode}/{commandText}")]

--- a/backend/Origam.Server/Controller/WorkQueueController.cs
+++ b/backend/Origam.Server/Controller/WorkQueueController.cs
@@ -60,34 +60,31 @@ public class WorkQueueController : ControllerBase
             workQueueService.HandleAction(workQueueCode, commandText, workQueueEntryId);
             return Ok();
         }
-        catch (Exception ex)
+        catch (RuleException ruleException)
         {
             if (log.IsErrorEnabled)
             {
-                log.Error(ex.Message, ex);
+                log.Error(ruleException.Message, ruleException);
             }
-            string output;
-            if (ex is RuleException ruleException)
+            string output = String.Format(
+                format: "{{\"Message\" : {0}, \"RuleResult\" : {1}}}",
+                JsonConvert.SerializeObject(ruleException.Message),
+                JsonConvert.SerializeObject(ruleException.RuleResult)
+            );
+            return BadRequest(output);
+        }
+        catch (ArgumentOutOfRangeException argumentException)
+        {
+            if (log.IsErrorEnabled)
             {
-                output = String.Format(
-                    format: "{{\"Message\" : {0}, \"RuleResult\" : {1}}}",
-                    JsonConvert.SerializeObject(ruleException.Message),
-                    JsonConvert.SerializeObject(ruleException.RuleResult)
-                );
+                log.Error(argumentException.Message, argumentException);
             }
-            else if (ex is ArgumentOutOfRangeException argumentException)
-            {
-                output = String.Format(
-                    format: "{{\"Message\" : {0}, \"ParamName\" : {1}, \"ActualValue\" : {2}}}",
-                    JsonConvert.SerializeObject(argumentException.Message),
-                    JsonConvert.SerializeObject(argumentException.ParamName),
-                    JsonConvert.SerializeObject(argumentException.ActualValue)
-                );
-            }
-            else
-            {
-                output = JsonConvert.SerializeObject(ex);
-            }
+            string output = String.Format(
+                format: "{{\"Message\" : {0}, \"ParamName\" : {1}, \"ActualValue\" : {2}}}",
+                JsonConvert.SerializeObject(argumentException.Message),
+                JsonConvert.SerializeObject(argumentException.ParamName),
+                JsonConvert.SerializeObject(argumentException.ActualValue)
+            );
             return BadRequest(output);
         }
     }

--- a/backend/Origam.Server/Controller/WorkQueueController.cs
+++ b/backend/Origam.Server/Controller/WorkQueueController.cs
@@ -26,6 +26,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
 using Newtonsoft.Json;
 using Origam.Service.Core;
 using Origam.Workbench.Services;
@@ -39,6 +40,13 @@ public class WorkQueueController : ControllerBase
     private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
         System.Reflection.MethodBase.GetCurrentMethod().DeclaringType
     );
+
+    private readonly IStringLocalizer<SharedResources> localizer;
+
+    public WorkQueueController(IStringLocalizer<SharedResources> localizer)
+    {
+        this.localizer = localizer;
+    }
 
     [HttpPost]
     [Route("workQueue/{workQueueCode}/{commandText}")]
@@ -60,31 +68,37 @@ public class WorkQueueController : ControllerBase
             workQueueService.HandleAction(workQueueCode, commandText, workQueueEntryId);
             return Ok();
         }
-        catch (RuleException ruleException)
+        catch (Exception ex)
         {
             if (log.IsErrorEnabled)
             {
-                log.Error(ruleException.Message, ruleException);
+                log.Error(ex.Message, ex);
             }
-            string output = String.Format(
-                format: "{{\"Message\" : {0}, \"RuleResult\" : {1}}}",
-                JsonConvert.SerializeObject(ruleException.Message),
-                JsonConvert.SerializeObject(ruleException.RuleResult)
-            );
-            return BadRequest(output);
-        }
-        catch (ArgumentOutOfRangeException argumentException)
-        {
-            if (log.IsErrorEnabled)
+            string output;
+            if (ex is RuleException ruleException)
             {
-                log.Error(argumentException.Message, argumentException);
+                output = String.Format(
+                    format: "{{\"Message\" : {0}, \"RuleResult\" : {1}}}",
+                    JsonConvert.SerializeObject(ruleException.Message),
+                    JsonConvert.SerializeObject(ruleException.RuleResult)
+                );
             }
-            string output = String.Format(
-                format: "{{\"Message\" : {0}, \"ParamName\" : {1}, \"ActualValue\" : {2}}}",
-                JsonConvert.SerializeObject(argumentException.Message),
-                JsonConvert.SerializeObject(argumentException.ParamName),
-                JsonConvert.SerializeObject(argumentException.ActualValue)
-            );
+            else if (ex is ArgumentOutOfRangeException argumentException)
+            {
+                output = String.Format(
+                    format: "{{\"Message\" : {0}, \"ParamName\" : {1}, \"ActualValue\" : {2}}}",
+                    JsonConvert.SerializeObject(argumentException.Message),
+                    JsonConvert.SerializeObject(argumentException.ParamName),
+                    JsonConvert.SerializeObject(argumentException.ActualValue)
+                );
+            }
+            else
+            {
+                output = String.Format(
+                    format: "{{\"Message\" : {0}}}",
+                    JsonConvert.SerializeObject(localizer["UnknownError"].ToString())
+                );
+            }
             return BadRequest(output);
         }
     }

--- a/backend/Origam.Server/Resources/SharedResources.cs-CZ.resx
+++ b/backend/Origam.Server/Resources/SharedResources.cs-CZ.resx
@@ -126,6 +126,12 @@
   <data name="ErrorBlobNotAvailable" xml:space="preserve">
     <value>BLOB již není k dispozici.</value>
   </data>
+  <data name="ErrorBlobDownloadFailed" xml:space="preserve">
+    <value>Při zpracování požadavku na stažení došlo k chybě.</value>
+  </data>
+  <data name="ErrorBlobUploadFailed" xml:space="preserve">
+    <value>Při zpracování požadavku na nahrání došlo k chybě.</value>
+  </data>
   <data name="ErrorBlobMemberBlobLookupNotSpecified" xml:space="preserve">
     <value>Ani BlobMember, ani BlobLookupId nejsou specifikovány. Nelze stáhnout blob.</value>
   </data>

--- a/backend/Origam.Server/Resources/SharedResources.de.resx
+++ b/backend/Origam.Server/Resources/SharedResources.de.resx
@@ -126,6 +126,12 @@
   <data name="ErrorBlobNotAvailable" xml:space="preserve">
     <value>BLOB ist nicht mehr verfügbar.</value>
   </data>
+  <data name="ErrorBlobDownloadFailed" xml:space="preserve">
+    <value>Beim Verarbeiten der Download-Anforderung ist ein Fehler aufgetreten.</value>
+  </data>
+  <data name="ErrorBlobUploadFailed" xml:space="preserve">
+    <value>Beim Verarbeiten der Upload-Anforderung ist ein Fehler aufgetreten.</value>
+  </data>
   <data name="ErrorBlobMemberBlobLookupNotSpecified" xml:space="preserve">
     <value>Sowohl BlobMember als auch BlobLookupId sind nicht angegeben. Blob kann nicht heruntergeladen werden.</value>
   </data>

--- a/backend/Origam.Server/Resources/SharedResources.fr.resx
+++ b/backend/Origam.Server/Resources/SharedResources.fr.resx
@@ -126,6 +126,12 @@
   <data name="ErrorBlobNotAvailable" xml:space="preserve">
     <value>BLOB no longer available.</value>
   </data>
+  <data name="ErrorBlobDownloadFailed" xml:space="preserve">
+    <value>Une erreur s'est produite lors du traitement de la demande de téléchargement.</value>
+  </data>
+  <data name="ErrorBlobUploadFailed" xml:space="preserve">
+    <value>Une erreur s'est produite lors du traitement de la demande d'envoi.</value>
+  </data>
   <data name="ErrorBlobMemberBlobLookupNotSpecified" xml:space="preserve">
     <value>Both BlobMember and BlobLookupId are not specified. Cannot download blob.</value>
   </data>

--- a/backend/Origam.Server/Resources/SharedResources.resx
+++ b/backend/Origam.Server/Resources/SharedResources.resx
@@ -126,6 +126,12 @@
   <data name="ErrorBlobNotAvailable" xml:space="preserve">
     <value>BLOB no longer available.</value>
   </data>
+  <data name="ErrorBlobDownloadFailed" xml:space="preserve">
+    <value>An error occurred while processing the download request.</value>
+  </data>
+  <data name="ErrorBlobUploadFailed" xml:space="preserve">
+    <value>An error occurred while processing the upload request.</value>
+  </data>
   <data name="ErrorBlobMemberBlobLookupNotSpecified" xml:space="preserve">
     <value>Both BlobMember and BlobLookupId are not specified. Cannot download blob.</value>
   </data>


### PR DESCRIPTION
Replace raw exception objects in StatusCode responses with localized error messages across BlobController, ChatController, ReportController, and WorkQueueController. Split WorkQueueController catch blocks by exception type for cleaner handling.

Warning: We absolutely need to test this on a real project before we merge!
