### PR TITLE
FIX: New Deployment Version throws 500 /architect-html

### DIFF
--- a/backend/Origam.Architect.Server/Utils/PropertyUtils.cs
+++ b/backend/Origam.Architect.Server/Utils/PropertyUtils.cs
@@ -21,7 +21,6 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 using System.ComponentModel;
 using System.Reflection;
-using Origam.Extensions;
 
 namespace Origam.Architect.Server.Utils;
 
@@ -29,12 +28,8 @@ public static class PropertyUtils
 {
     public static bool CanBeEdited(PropertyInfo property)
     {
-        var browsableAttribute = property.GetAttribute<BrowsableAttribute>();
-        if (browsableAttribute == null)
-        {
-            return true;
-        }
-
-        return browsableAttribute.Browsable;
+        var browsableAttribute = (BrowsableAttribute)
+            Attribute.GetCustomAttribute(property, typeof(BrowsableAttribute), inherit: true);
+        return browsableAttribute?.Browsable ?? true;
     }
 }


### PR DESCRIPTION
* Use `Attribute.GetCustomAttribute` with `inherit:true` in `PropertyUtils.CanBeEdited`; `PropertyInfo.GetCustomAttributes` silently ignores inheritance for properties.
* Restores filtering of `Type[]` schema-item members (e.g. `NewItemTypes`, `NameableTypes`) whose overrides do not re-declare `[Browsable(false)]`.
* Fixes the HTML Architect crash with `Serialization of 'System.Type' instances is not supported` when opening editors for items like `DeploymentVersion`.