### PR TITLE
FIX: HTML Architect auto-fill of Name (and other dependent fields) does not trigger when changing a reference

### DIFF
--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -92,6 +92,7 @@ export class GridEditorState implements IEditorState, IPropertyManager {
     property: EditorProperty,
     value: any,
   ): Generator<Promise<IUpdatePropertiesResult>, void, IUpdatePropertiesResult> {
+    const changedProperties: EditorProperty[] = [property];
     if (property.name === 'Name') {
       const oldName = property.value;
       for (const mappedName of ['MappedObjectName', 'MappedColumnName']) {
@@ -105,11 +106,12 @@ export class GridEditorState implements IEditorState, IPropertyManager {
             mapped.value === oldName)
         ) {
           mapped.value = value;
+          changedProperties.push(mapped);
         }
       }
     }
     property.value = value;
-    const changes = toChanges(this.properties);
+    const changes = toChanges(changedProperties);
     const updateResult = (yield this.architectApi.updateProperties(
       this.editorNode.origamId,
       changes,


### PR DESCRIPTION

## Root cause

The auto-fill logic lives in C# property setters on the model. For example,
[`DataStructureEntity.Entity`](backend/Origam.Schema.EntityModel/Data%20Structure/DataStructureEntity.cs#L72-L101):

```csharp
public ISchemaItem Entity
{
    get => ...;
    set
    {
        if (value == null)
        {
            EntityId = Guid.Empty;
            Name = "";
        }
        else
        {
            // ... type checks ...
            EntityId = (Guid)value.PrimaryKey["Id"];
            Name = Entity.Name;   // ← auto-fill happens here
        }
    }
}
```

The backend endpoint applies incoming changes via reflection, in order
([`EditorService.ChangesToEditorData`](backend/Origam.Architect.Server/Services/EditorService.cs#L212-L240)):

```csharp
foreach (var change in input.Changes)
{
    var propertyToChange = properties.FirstOrDefault(p => p.Name == change.Name);
    // ...
    propertyToChange.SetValue(editor.Item, newValue);
}
```

The problem: the frontend in `GridEditorState.onPropertyUpdated` was sending **all** properties on every edit, not just the changed one:

```typescript
property.value = value;
const changes = toChanges(this.properties);   // ← sends ALL properties
```

`Type.GetProperties()` in .NET returns derived-class properties before inherited ones, so the request order ends up as `[Entity, ..., Name, ...]`. The backend then:

1. Sets `Entity` → C# setter auto-fills `Name = Entity.Name` ✅
2. Continues the loop → sets `Name` back to the stale value the client still had ❌

The setter's side-effect is silently overwritten by the next iteration.

### Concrete example — request payload (before fix)

User changes `Entity` from `null` to `BusinessUnit`. Frontend sends:

```json
POST /PropertyEditor/Update
{
  "schemaItemId": "...",
  "changes": [
    { "name": "Entity",     "value": "9a7b8c2c-f8a8-4fed-8470-895d2618499a" },
    { "name": "Caption",    "value": null },
    { "name": "AllFields",  "value": "true" },
    ...
    { "name": "Name",       "value": "32" }    ← stale; the user never touched this
  ]
}
```

Result: `Name` ends up as `"32"` instead of `"BusinessUnit"`.

## Fix

Send only the properties that were actually mutated this call. Locally-mutated related properties (`MappedObjectName`, `MappedColumnName`) are tracked explicitly so the existing local auto-fill behavior is preserved.

```diff
   *onPropertyUpdated(
     property: EditorProperty,
     value: any,
   ): Generator<Promise<IUpdatePropertiesResult>, void, IUpdatePropertiesResult> {
+    const changedProperties: EditorProperty[] = [property];
     if (property.name === 'Name') {
       const oldName = property.value;
       for (const mappedName of ['MappedObjectName', 'MappedColumnName']) {
         const mapped = this.properties.find(p => p.name === mappedName);
         if (
           mapped &&
           !mapped.readOnly &&
           (mapped.value === null ||
             mapped.value === undefined ||
             mapped.value === '' ||
             mapped.value === oldName)
         ) {
           mapped.value = value;
+          changedProperties.push(mapped);
         }
       }
     }
     property.value = value;
-    const changes = toChanges(this.properties);
+    const changes = toChanges(changedProperties);
     const updateResult = (yield this.architectApi.updateProperties(
       this.editorNode.origamId,
       changes,
     )) as IUpdatePropertiesResult;
     for (const property of this.properties) {
       const propertyUpdate = updateResult.propertyUpdates.find(
         update => property.name === update.propertyName,
       );
       property.update(propertyUpdate);
     }
     this._isDirty = updateResult.isDirty;
   }
```

## Why this works

After the fix, when the user changes only `Entity`:

```json
POST /PropertyEditor/Update
{
  "schemaItemId": "...",
  "changes": [
    { "name": "Entity", "value": "9a7b8c2c-f8a8-4fed-8470-895d2618499a" }
  ]
}
```

Backend flow:
1. `SetValue(Entity, ...)` → C# setter runs → auto-fills `Name = "BusinessUnit"`
2. Loop ends — no further changes to overwrite the setter's side-effects
3. `GetEditorProperties` reads back all current values via reflection, including the new `Name`
4. Response contains the updated `Name`; frontend applies it via `property.update(...)`

The fix is intentionally **not** schema-item-specific. The auto-fill logic continues to live in C# setters where it already exists. The frontend simply stops clobbering the backend's work by sending back stale values for fields the user didn't touch.

## Scope — what else this fixes

Any schema item with a setter that has side-effects now works correctly. Known cases discovered while debugging:

| Class | Source property | Auto-filled fields |
|---|---|---|
| `DataStructureEntity` | `Entity` | `Name` |
| `DataStructureColumn` | `Field` | `Name`, `FinalColumn`, derived `NodeText` |
| `EntityRelationItem` | `RelatedEntity` | `Name` |
| `FunctionCall` | `Function` | `Name` (when previously null) |
| `DataConstantReference` | `DataConstant` | `Name` (when previously null) |
| `AggregatedColumn` | `Field` | `Name`, `DataType`, `DataLength` |
| `StateMachine` | `Entity` / `Field` | `Name` |

All of these were silently broken in HTML Architect before — none required a separate fix.

## Side benefits

- Request payload shrinks from ~15–25 properties to 1–3 per edit
- Less reflection work on the backend per `Update` call
- Eliminates the implicit dependency on `.NET`'s property iteration order
