### PR TITLE
FIX: Ux missing space between radio button and label

### DIFF
--- a/frontend-html/src/gui/Components/Form/RadioButton.module.scss
+++ b/frontend-html/src/gui/Components/Form/RadioButton.module.scss
@@ -18,17 +18,18 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
 .root {
-  position: absolute;
+	position: absolute;
 }
 
-.input{
-  margin-left: 0;
-  margin-top: 0;
-  cursor: pointer;
-  vertical-align: middle;
+.input {
+	margin-left: 0;
+	margin-top: 0;
+	cursor: pointer;
+	vertical-align: middle;
 }
 
-.label{
-  cursor: pointer;
-  vertical-align: middle;
+.label {
+	cursor: pointer;
+	vertical-align: middle;
+	margin-left: 4px;
 }


### PR DESCRIPTION
Before
<img width="1035" height="255" alt="image" src="https://github.com/user-attachments/assets/7e540390-782c-4712-9d55-2dd37d6f93fb" />
After
<img width="582" height="264" alt="image" src="https://github.com/user-attachments/assets/c5c4a93f-e7ae-47bc-bf5f-3a90f9993493" />
