### PR TITLE
FEATURE: Make property editor sections collapsible /architect-html

### DIFF
--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.module.scss
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.module.scss
@@ -25,12 +25,32 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
     border-radius: 0.25rem;
     overflow: hidden;
 
-    h4 {
+    .categoryHeader {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.25rem;
+      width: 100%;
       color: var(--brand);
       padding: 0.25rem;
-      margin-top: 0;
-      margin-bottom: 0.5rem;
+      margin: 0 0 0.5rem 0;
+      border: none;
       border-bottom: 1px solid var(--brand);
+      background: transparent;
+      cursor: pointer;
+      text-align: left;
+      font-size: 1rem;
+      font-weight: bold;
+      font-family: inherit;
+
+      &:hover {
+        background-color: var(--background2);
+      }
+
+      .chevron {
+        flex-shrink: 0;
+        color: var(--brand);
+      }
     }
 
     .property {
@@ -69,7 +89,7 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
   div.category {
     margin: 0;
     max-width: unset;
-    h4 {
+    .categoryHeader {
       display: none;
     }
     .property {

--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
@@ -34,8 +34,7 @@ const PropertyEditor = observer(
     propertyManager: IPropertyManager;
     compact?: boolean;
   }) => {
-    const rootStore = useContext(RootStoreContext);
-    const uiState = rootStore.uiState;
+    const { uiState } = useContext(RootStoreContext);
 
     if (!props.properties) {
       return null;

--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
@@ -45,7 +45,7 @@ const PropertyEditor = observer(
     return (
       <div className={cn(S.root, { [S.compact]: props.compact })}>
         {sortedCategories.map(category => {
-          const categoryKey = category ?? 'Misc';
+          const categoryKey = (category ?? 'Misc').replace(/^\((.*)\)$/, '$1');
           const collapsed = !props.compact && uiState.isPropertySectionCollapsed(categoryKey);
           const Chevron = collapsed ? VscChevronRight : VscChevronDown;
           return (

--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
@@ -48,6 +48,7 @@ const PropertyEditor = observer(
         {sortedCategories.map(category => {
           const categoryKey = category ?? 'Misc';
           const collapsed = !props.compact && uiState.isPropertySectionCollapsed(categoryKey);
+          const Chevron = collapsed ? VscChevronRight : VscChevronDown;
           return (
             <div className={S.category} key={category}>
               {!props.compact && (
@@ -58,11 +59,7 @@ const PropertyEditor = observer(
                   aria-expanded={!collapsed}
                 >
                   <span>{categoryKey}</span>
-                  {collapsed ? (
-                    <VscChevronRight className={S.chevron} />
-                  ) : (
-                    <VscChevronDown className={S.chevron} />
-                  )}
+                  <Chevron className={S.chevron} />
                 </button>
               )}
               {!collapsed &&

--- a/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
+++ b/architect-html/src/components/editors/propertyEditor/PropertyEditor.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2005 - 2026 Advantage Solutions, s. r. o. 
+Copyright 2005 - 2026 Advantage Solutions, s. r. o.
 
 This file is part of ORIGAM (http://www.origam.org).
 
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { RootStoreContext } from '@/main';
 import { EditorProperty } from '@editors/gridEditor/EditorProperty';
 import { IPropertyManager } from '@editors/propertyEditor/IPropertyManager';
 import S from '@editors/propertyEditor/PropertyEditor.module.scss';
@@ -24,7 +25,8 @@ import SinglePropertyEditor from '@editors/propertyEditor/SinglePropertyEditor.t
 import { getSortedProperties } from '@editors/propertyEditor/utils';
 import cn from 'classnames';
 import { observer } from 'mobx-react-lite';
-import { VscWarning } from 'react-icons/vsc';
+import { useContext } from 'react';
+import { VscChevronDown, VscChevronRight, VscWarning } from 'react-icons/vsc';
 
 const PropertyEditor = observer(
   (props: {
@@ -32,6 +34,9 @@ const PropertyEditor = observer(
     propertyManager: IPropertyManager;
     compact?: boolean;
   }) => {
+    const rootStore = useContext(RootStoreContext);
+    const uiState = rootStore.uiState;
+
     if (!props.properties) {
       return null;
     }
@@ -40,27 +45,46 @@ const PropertyEditor = observer(
 
     return (
       <div className={cn(S.root, { [S.compact]: props.compact })}>
-        {sortedCategories.map(category => (
-          <div className={S.category} key={category}>
-            {!props.compact && <h4>{(category ?? 'Misc').replace(/^\((.*)\)$/, '$1')}</h4>}
-            {groupedProperties[category].map((property: EditorProperty) => (
-              <div className={S.property} key={property.name}>
-                <div
-                  title={property.error}
-                  className={cn(S.propertyName, { [S.errorProperty]: property.error })}
+        {sortedCategories.map(category => {
+          const categoryKey = category ?? 'Misc';
+          const collapsed = !props.compact && uiState.isPropertySectionCollapsed(categoryKey);
+          return (
+            <div className={S.category} key={category}>
+              {!props.compact && (
+                <button
+                  type="button"
+                  className={S.categoryHeader}
+                  onClick={() => uiState.togglePropertySectionCollapsed(categoryKey)}
+                  aria-expanded={!collapsed}
                 >
-                  {property.error && <VscWarning className={S.errorIcon} />}
-                  <span>{property.name}</span>
-                </div>
-                <SinglePropertyEditor
-                  property={property}
-                  propertyManager={props.propertyManager}
-                  compact={props.compact}
-                />
-              </div>
-            ))}
-          </div>
-        ))}
+                  <span>{categoryKey}</span>
+                  {collapsed ? (
+                    <VscChevronRight className={S.chevron} />
+                  ) : (
+                    <VscChevronDown className={S.chevron} />
+                  )}
+                </button>
+              )}
+              {!collapsed &&
+                groupedProperties[category].map((property: EditorProperty) => (
+                  <div className={S.property} key={property.name}>
+                    <div
+                      title={property.error}
+                      className={cn(S.propertyName, { [S.errorProperty]: property.error })}
+                    >
+                      {property.error && <VscWarning className={S.errorIcon} />}
+                      <span>{property.name}</span>
+                    </div>
+                    <SinglePropertyEditor
+                      property={property}
+                      propertyManager={props.propertyManager}
+                      compact={props.compact}
+                    />
+                  </div>
+                ))}
+            </div>
+          );
+        })}
       </div>
     );
   },

--- a/architect-html/src/stores/UiState.ts
+++ b/architect-html/src/stores/UiState.ts
@@ -30,7 +30,9 @@ enum EStorageKeys {
 
 type TPropertySectionCollapsed = { [category: string]: boolean };
 
-const DEFAULT_COLLAPSED_CATEGORIES = new Set<string>(['Info']);
+function isCollapsedByDefault(category: string): boolean {
+  return category === 'Info';
+}
 
 export const SIDEBAR_MIN_WIDTH = 250;
 export const SIDEBAR_MAX_WIDTH = 1200;
@@ -105,7 +107,7 @@ export class UIState {
   isPropertySectionCollapsed(category: string): boolean {
     const stored = this.propertySectionCollapsed[category];
     if (typeof stored === 'boolean') return stored;
-    return DEFAULT_COLLAPSED_CATEGORIES.has(category);
+    return isCollapsedByDefault(category);
   }
 
   @action

--- a/architect-html/src/stores/UiState.ts
+++ b/architect-html/src/stores/UiState.ts
@@ -105,9 +105,7 @@ export class UIState {
   }
 
   isPropertySectionCollapsed(category: string): boolean {
-    const stored = this.propertySectionCollapsed[category];
-    if (typeof stored === 'boolean') return stored;
-    return isCollapsedByDefault(category);
+    return this.propertySectionCollapsed[category] ?? isCollapsedByDefault(category);
   }
 
   @action

--- a/architect-html/src/stores/UiState.ts
+++ b/architect-html/src/stores/UiState.ts
@@ -25,7 +25,12 @@ enum EStorageKeys {
   SETTINGS = 'settings',
   DEPLOYMENT_SCRIPTS_GENERATOR_STATE = 'deploymentScriptsGeneratorState',
   SIDEBAR_WIDTH = 'sidebarWidth',
+  PROPERTY_SECTION_COLLAPSED = 'propertySectionCollapsed',
 }
+
+type TPropertySectionCollapsed = { [category: string]: boolean };
+
+const DEFAULT_COLLAPSED_CATEGORIES = new Set<string>(['Info']);
 
 export const SIDEBAR_MIN_WIDTH = 250;
 export const SIDEBAR_MAX_WIDTH = 1200;
@@ -58,6 +63,7 @@ const STORAGE_DEFAULTS = {
   [EStorageKeys.SETTINGS]: defaultSettings,
   [EStorageKeys.DEPLOYMENT_SCRIPTS_GENERATOR_STATE]: defaultDsGeneratorState,
   [EStorageKeys.SIDEBAR_WIDTH]: SIDEBAR_DEFAULT_WIDTH,
+  [EStorageKeys.PROPERTY_SECTION_COLLAPSED]: {} as TPropertySectionCollapsed,
 } as const;
 
 function clampSidebarWidth(value: number): number {
@@ -72,6 +78,7 @@ export class UIState {
     ...defaultDsGeneratorState,
   };
   @observable accessor sidebarWidth: number = SIDEBAR_DEFAULT_WIDTH;
+  @observable accessor propertySectionCollapsed: TPropertySectionCollapsed = {};
 
   constructor() {
     this.expandedNodes = this.loadStateFromLocalStorage(EStorageKeys.TREE_EXPANDED_NODES);
@@ -89,6 +96,26 @@ export class UIState {
       const parsed = Number.parseFloat(rawSidebarWidth);
       this.sidebarWidth = clampSidebarWidth(parsed);
     }
+
+    this.propertySectionCollapsed = this.loadStateFromLocalStorage(
+      EStorageKeys.PROPERTY_SECTION_COLLAPSED,
+    );
+  }
+
+  isPropertySectionCollapsed(category: string): boolean {
+    const stored = this.propertySectionCollapsed[category];
+    if (typeof stored === 'boolean') return stored;
+    return DEFAULT_COLLAPSED_CATEGORIES.has(category);
+  }
+
+  @action
+  togglePropertySectionCollapsed(category: string) {
+    const next = !this.isPropertySectionCollapsed(category);
+    this.propertySectionCollapsed = { ...this.propertySectionCollapsed, [category]: next };
+    localStorage.setItem(
+      EStorageKeys.PROPERTY_SECTION_COLLAPSED,
+      JSON.stringify(this.propertySectionCollapsed),
+    );
   }
 
   @action


### PR DESCRIPTION
* Add clickable section headers with chevron to expand/collapse property categories
* Persist collapsed state per category in localStorage via UIState
* Collapse the Info section by default since it is rarely needed
* Add ARIA attributes