### PR TITLE
DEV: Docker dev environment with devcontainer

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -21,3 +21,10 @@ OrigamSettings__DefaultSchemaExtensionId=f17329d6-3143-420a-a2e6-30e431eea51d
 # Optional: point the devcontainer at your own model (must be under the repo
 # mount /workspaces/origam/...).
 # OrigamSettings__ModelSourceControlLocation=/workspaces/origam/your-model
+
+# Host ports for the published frontends (the DB + backends aren't host-published
+# here — VS Code forwards them). Override only on conflict with another stack.
+# FRONTEND_PORT also drives OIDC (ExternalDomain / AccessTokenIssuer /
+# VITE_OIDC_AUTHORITY) so login works on the remapped port.
+# FRONTEND_PORT=5173
+# ARCHITECT_FRONTEND_PORT=5174

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,23 @@
+# Copy to .env (gitignored) and fill in. The DB password is NOT baked into the
+# compose file — `up` reads it from here. Compose auto-loads .env from
+# .devcontainer/ (the compose file's directory), so no --env-file prefix is needed:
+#
+#   docker compose -f .devcontainer/docker-compose.yml up -d
+
+# SQL Server `sa` password. Must meet SQL Server policy (8+ chars, upper/lower/digit).
+# Used by the database container, the healthcheck, and the backend connection string.
+# MUST match the password the devcontainer-db-data volume was initialized with —
+# MSSQL only honors MSSQL_SA_PASSWORD on first init, so changing this alone does NOT
+# re-set an existing database's sa password (needs `down -v` + restart).
+MSSQL_SA_PASSWORD=Origam@Dev123
+
+# Project name (shown in the app / used for model identification).
+OrigamSettings__Name=DevProject
+
+# Root schema extension (package) id of the model mounted into the devcontainer.
+# f17329d6-... is the root package of the test model at model-tests/model.
+OrigamSettings__DefaultSchemaExtensionId=f17329d6-3143-420a-a2e6-30e431eea51d
+
+# Optional: point the devcontainer at your own model (must be under the repo
+# mount /workspaces/origam/...).
+# OrigamSettings__ModelSourceControlLocation=/workspaces/origam/your-model

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+# Devcontainer for ORIGAM backend dev/debug on Linux (net8.0 subset only).
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+
+# libgdiplus for System.Drawing (reporting).
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
+      ca-certificates curl sudo git make g++ xmlstarlet \
+      libgif-dev autoconf libtool automake gettext \
+      libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev libpango1.0-dev \
+ && git clone --depth 1 https://github.com/mono/libgdiplus.git /tmp/libgdiplus \
+ && cd /tmp/libgdiplus && ./autogen.sh --with-pango --prefix=/usr && make && make install \
+ && cd / && rm -rf /tmp/libgdiplus \
+ && apt-get -y purge autoconf automake libtool \
+ && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
+
+# netcoredbg (Samsung, MIT) — OSS DAP debugger. Pinned to 3.1.3: 3.2.0+ needs
+# glibc 2.38 but sdk:8.0 (Debian bookworm) has 2.36.
+RUN ARCH=$(dpkg --print-architecture) \
+ && curl -fsSL "https://github.com/Samsung/netcoredbg/releases/download/3.1.3-1062/netcoredbg-linux-${ARCH}.tar.gz" \
+    | tar -xz -C /opt \
+ && ln -s /opt/netcoredbg/netcoredbg /usr/local/bin/netcoredbg

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -42,19 +42,21 @@ Both proxy to `devcontainer:8080`/`8081` — i.e. to whatever backend you launch
 from the editor. So: F5 the server, then load the frontend in a browser, hit
 breakpoints as you click.
 
-## Override DB / model
+## DB password / model
 
-Every `OrigamSettings__*` var and `SA_PASSWORD` is `${VAR:-default}` in
-`docker-compose.yml`, so you can repoint the DB or model without editing the
-file. Drop a `.devcontainer/.env` (auto-loaded by Compose, gitignored):
+The DB password is NOT baked in — copy `.devcontainer/.env.example` to
+`.devcontainer/.env` (gitignored) and set `MSSQL_SA_PASSWORD`. Compose auto-loads
+`.env` from `.devcontainer/`, so no `--env-file` prefix is needed:
 
 ```
+MSSQL_SA_PASSWORD=YourPassword
 OrigamSettings__ModelSourceControlLocation=/workspaces/origam/your-model
 OrigamSettings__DefaultSchemaExtensionId=<your root package id>
-SA_PASSWORD=YourPassword
 ```
 
-The model path must be inside the repo mount (`/workspaces/origam/...`).
+The `OrigamSettings__*` vars are `${VAR:-default}` in `docker-compose.yml`, so
+they're optional (defaults point at the bundled test model); `MSSQL_SA_PASSWORD` is
+required. The model path must be inside the repo mount (`/workspaces/origam/...`).
 
 ## Debugging in your editor
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,106 @@
+# ORIGAM devcontainer (full-stack dev/debug on Linux)
+
+A sandboxed, editor-attached dev environment. One `docker compose up` brings up
+SQL Server + the dev container + **both** frontends (frontend-html, architect-html).
+Reopen in VS Code/Cursor to debug the .NET backends with breakpoints.
+
+Builds the **net8.0 subset** of Origam (Server, Architect.Server, Scheduler). The
+net472 projects (old WinForms architect, Gui.Win) don't build on Linux and aren't
+needed here. The C# extension will warn about them on load — cosmetic, ignorable.
+
+## Open it
+
+VS Code / Cursor (Dev Containers extension) → **Dev Containers: Reopen in Container**.
+Compose brings up: `database` (mssql), `devcontainer` (editor attaches here),
+`frontend` (5173), `architect-frontend` (5174).
+
+## Debug the backends (F5)
+
+`.vscode/launch.json` has two configs, each with a build task that stages config
+into `bin/` before launch:
+
+- **Debug Origam.Server** — runtime server on 8080. Full OIDC; deploys the schema
+  on a fresh DB. Seed a user once via `https://localhost:5173/Account/RegisterInitialUser`,
+  then login through the frontend.
+- **Debug Architect.Server** — architect backend on 8081. Note: the architect does
+  **not** deploy schema on a fresh DB, so run the server once first to warm it.
+
+Run the backends without debugging:
+
+```bash
+.devcontainer/run-architect.sh         # architect, 8081
+.devcontainer/run-server.sh            # runtime server, 8080
+```
+
+## Use the frontends
+
+- `https://localhost:5173` — runtime app (login via the debugged server). Accept
+  Vite's self-signed cert.
+- `http://localhost:5174` — architect UI (no auth; HTTP).
+
+Both proxy to `devcontainer:8080`/`8081` — i.e. to whatever backend you launched
+from the editor. So: F5 the server, then load the frontend in a browser, hit
+breakpoints as you click.
+
+## Override DB / model
+
+Every `OrigamSettings__*` var and `SA_PASSWORD` is `${VAR:-default}` in
+`docker-compose.yml`, so you can repoint the DB or model without editing the
+file. Drop a `.devcontainer/.env` (auto-loaded by Compose, gitignored):
+
+```
+OrigamSettings__ModelSourceControlLocation=/workspaces/origam/your-model
+OrigamSettings__DefaultSchemaExtensionId=<your root package id>
+SA_PASSWORD=YourPassword
+```
+
+The model path must be inside the repo mount (`/workspaces/origam/...`).
+
+## Debugging in your editor
+
+`devcontainer.json` declares `ms-dotnettools.csharp` (official C# extension,
+which uses MS-proprietary **vsdbg**) — that's the most-used path and it works
+out of the box in base VS Code. `netcoredbg` (Samsung, MIT, OSS) is also
+installed on PATH (`/usr/local/bin/netcoredbg`) for everyone else. Pick your row:
+
+| Editor | What to do |
+|---|---|
+| **VS Code** | Already wired. `.vscode/launch.json` has `Debug Origam.Server` and `Debug Architect.Server`; F5 builds, launches, and hits breakpoints (vsdbg). |
+| **Cursor** | Cursor ships its own `anysphere.csharp` (netcoredbg, May 2025). If it and the repo-declared official extension are both active you'll get a conflict prompt — disable `ms-dotnettools.csharp` for the workspace and use Anysphere C#. |
+| **Rider** | Connect via JetBrains Gateway / Remote Development (Dev Containers). The IDE backend runs in the container and brings its own .NET debugger — no vsdbg/netcoredbg needed. Rider ignores `customizations.vscode`, so it works as-is. |
+| **VSCodium / code-server / Gitpod** | vsdbg won't run on non-Microsoft builds. Install `muhammad-sammy.csharp` from open-vsx — a drop-in fork that swaps in netcoredbg under the same `coreclr` type, so `.vscode/launch.json` works unchanged. |
+| **Anything else** (Zed, neovim, helix, agents) | `netcoredbg` is on PATH at `/usr/local/bin/netcoredbg` — point your editor's DAP client at it. Or use `netcoredbg-server.sh` (below) and attach over TCP. |
+
+### Editor-agnostic DAP (TCP)
+
+```bash
+.devcontainer/netcoredbg-server.sh architect     # default; port 47000
+.devcontainer/netcoredbg-server.sh server        # sets the OIDC issuer env too
+PORT=48000 .devcontainer/netcoredbg-server.sh server
+```
+
+Build + stage configs first (the script launches the already-built DLL):
+`bash .devcontainer/debug-build-architect.sh` (architect) or `bash .devcontainer/debug-build-server.sh`
+(server). Then attach your DAP client to `localhost:47000` (forwarded to the host).
+
+The devcontainer spec has no `extends`, so the repo can only declare one C#
+extension — the table above is how non-VS-Code editors layer netcoredbg on top.
+
+## Relationship to the main dev stack (`docker compose up`)
+
+Two separate things, both kept intentionally:
+
+- **Main stack** (`docker-compose.yml` at repo root): published DLLs, prod-shaped
+  entrypoint, for running/evaluating/QA — no editor.
+- **This devcontainer**: source + PDBs, editor-attached, for changing code.
+
+They share Dockerfiles/templates but stage config differently. **If you change
+appsettings substitutions in one path, update the other** — e.g.
+`debug-build-server.sh` and `docker/server/linux/configureServer.sh` both do the
+`pathchatapp`/`chatinterval`/`ExternalDomain` sed substitutions; keep them in sync.
+
+## Not included
+
+- No hot reload (`dotnet watch`). Edit → F5 (rebuilds).
+- Frontend JS breakpoints: Vite serves source maps, so use browser DevTools or
+  VS Code's JS debugger — standard, not wired here.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -38,6 +38,8 @@ Run the backends without debugging:
   Vite's self-signed cert.
 - `http://localhost:5174` — architect UI (no auth; HTTP).
 
+These ports are overridable via `FRONTEND_PORT`/`ARCHITECT_FRONTEND_PORT` in `.devcontainer/.env` (the runtime one also retunes OIDC).
+
 Both proxy to `devcontainer:8080`/`8081` — i.e. to whatever backend you launched
 from the editor. So: F5 the server, then load the frontend in a browser, hit
 breakpoints as you click.

--- a/.devcontainer/debug-build-architect.sh
+++ b/.devcontainer/debug-build-architect.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build + stage configs for debugging Origam.Architect.Server (no run — the
+# debugger launches the DLL). PreLaunchTask for the VS Code debug config.
+set -e
+cd /workspaces/origam/backend
+
+CONFIG="Debug Architect Server"
+dotnet build Origam.Architect.Server/Origam.Architect.Server.csproj \
+    /p:Configuration="$CONFIG" -v:minimal
+
+BIN="Origam.Architect.Server/bin/$CONFIG/net8.0"
+cp ../docker/server/_OrigamSettings.template "$BIN/OrigamSettings.config"
+source ../docker/server/linux/fill_origam_settings_config.sh
+fill_origam_settings_config "$BIN/OrigamSettings.config" "${DatabaseType}"
+cp ../docker/dev/appsettings.architect.json "$BIN/appsettings.json"
+cp ../docker/dev/log4net.config "$BIN/log4net.config"
+mkdir -p "$BIN/ClientApplication"

--- a/.devcontainer/debug-build-server.sh
+++ b/.devcontainer/debug-build-server.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Build + stage configs for debugging Origam.Server (no run — the debugger
+# launches the DLL). Mirrors docker/dev/entrypoint.dev.sh + configureServer.sh
+# but against the source build's bin output.
+set -e
+cd /workspaces/origam/backend
+
+CONFIG="Debug Server"
+dotnet build Origam.Server/Origam.Server.csproj /p:Configuration="$CONFIG" -v:minimal
+
+BIN="Origam.Server/bin/Debug/net8.0"
+
+# appsettings.json from the shared template, substituting ExternalDomain
+# (OIDC redirect URIs). Default to the server's own URL if unset.
+EXTERNAL_DOMAIN="${ExternalDomain_SetOnStart:-https://localhost:5173}"
+cp ../docker/server/_appsettings.template "$BIN/appsettings.json"
+sed -i "s|ExternalDomain|${EXTERNAL_DOMAIN}|g" "$BIN/appsettings.json"
+# Match configureServer.sh's chat substitutions + fix the template's trailing
+# comma after ServerClient.ClientSecret.
+sed -i "s|pathchatapp||" "$BIN/appsettings.json"
+sed -i "s|chatinterval|0|" "$BIN/appsettings.json"
+sed -i "/serverSecret/s/,$//" "$BIN/appsettings.json"
+
+# OrigamSettings.config from the shared template + OrigamSettings__* env.
+cp ../docker/server/_OrigamSettings.template "$BIN/OrigamSettings.config"
+source ../docker/server/linux/fill_origam_settings_config.sh
+fill_origam_settings_config "$BIN/OrigamSettings.config" "${DatabaseType}"
+
+cp ../docker/dev/log4net.config "$BIN/log4net.config"
+
+# PathToClientApp is hardcoded to /home/origam/server_bin/clients/origam in the
+# template; Startup builds a PhysicalFileProvider for it unconditionally. Create
+# it empty (dev frontend runs in Vite).
+mkdir -p /home/origam/server_bin/clients/origam

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json
+{
+  "name": "ORIGAM",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  // frontend/architect-frontend depend on `devcontainer`, not vice versa, so an
+  // editor that starts only the primary service + its deps would skip them —
+  // list the full stack.
+  "runServices": ["database", "devcontainer", "frontend", "architect-frontend"],
+  "workspaceFolder": "/workspaces/origam",
+
+  "forwardPorts": [8081, 8080, 47000],
+  "portsAttributes": {
+    "8081": { "label": "Architect API" },
+    "8080": { "label": "Runtime Server API" },
+    "47000": { "label": "DAP (netcoredbg)" }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp"
+      ]
+    }
+  },
+
+  "postCreateCommand": "dotnet restore /workspaces/origam/backend/Origam.sln"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,82 @@
+# DB + dev container on a shared network (devcontainer reaches the DB at
+# database:1433). Editors attach to the `devcontainer` service; see
+# devcontainer.json. The repo is mounted at /workspaces/origam.
+services:
+  database:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "${SA_PASSWORD:-Origam@Dev123}"
+      MSSQL_AGENT_ENABLED: "true"
+    volumes:
+      - devcontainer-db-data:/var/opt/mssql
+      - ../docker/dev/initdb:/docker-entrypoint-initdb.d:ro
+    entrypoint: ["/bin/bash", "/docker-entrypoint-initdb.d/run-init.sh"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD:-Origam@Dev123}" -C -Q ''SELECT 1'' || exit 1',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+  devcontainer:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    image: origam/devcontainer:dev
+    command: sleep infinity
+    depends_on:
+      database:
+        condition: service_healthy
+    environment:
+      - DatabaseType=mssql
+      - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
+      - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
+      - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${SA_PASSWORD:-Origam@Dev123};}
+      - OrigamSettings__ModelSourceControlLocation=${OrigamSettings__ModelSourceControlLocation:-/workspaces/origam/model-tests/model}
+    volumes:
+      - ..:/workspaces/origam:cached
+      - devcontainer-nuget:/root/.nuget/packages
+      - devcontainer-dataprotection:/root/.aspnet/DataProtection-Keys
+
+  architect-frontend:
+    build:
+      context: ../architect-html
+      dockerfile: ../docker/DockerfileVite.dev
+    image: origam/architect-frontend:dev
+    ports:
+      - "5174:5173"
+    volumes:
+      - ../architect-html:/src/frontend-html
+    environment:
+      - VITE_ARCHITECT_PROXY_TARGET_HTTPS=http://devcontainer:8081
+      - VITE_ARCHITECT_PROXY_TARGET_HTTP=http://devcontainer:8081
+      - VITE_HOST=0.0.0.0
+      - VITE_DISABLE_HTTPS=true
+    depends_on:
+      - devcontainer
+
+  frontend:
+    build:
+      context: ../frontend-html
+      dockerfile: ../docker/DockerfileVite.dev
+    image: origam/frontend:dev
+    ports:
+      - "5173:5173"
+    volumes:
+      - ../frontend-html:/src/frontend-html
+    environment:
+      - VITE_PROXY_TARGET=http://devcontainer:8080
+      - VITE_HOST=0.0.0.0
+      - VITE_OIDC_AUTHORITY=https://localhost:5173
+    depends_on:
+      - devcontainer
+
+volumes:
+  devcontainer-db-data:
+  devcontainer-nuget:
+  devcontainer-dataprotection:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: mcr.microsoft.com/mssql/server:2019-latest
     environment:
       ACCEPT_EULA: "Y"
-      SA_PASSWORD: "${SA_PASSWORD:-Origam@Dev123}"
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD:-}"
       MSSQL_AGENT_ENABLED: "true"
     volumes:
       - devcontainer-db-data:/var/opt/mssql
@@ -16,7 +16,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD:-Origam@Dev123}" -C -Q ''SELECT 1'' || exit 1',
+          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${MSSQL_SA_PASSWORD:-}" -C -Q ''SELECT 1'' || exit 1',
         ]
       interval: 10s
       timeout: 5s
@@ -36,7 +36,7 @@ services:
       - DatabaseType=mssql
       - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
       - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
-      - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${SA_PASSWORD:-Origam@Dev123};}
+      - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${MSSQL_SA_PASSWORD:-};}
       - OrigamSettings__ModelSourceControlLocation=${OrigamSettings__ModelSourceControlLocation:-/workspaces/origam/model-tests/model}
     volumes:
       - ..:/workspaces/origam:cached

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
       - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${MSSQL_SA_PASSWORD:-};}
       - OrigamSettings__ModelSourceControlLocation=${OrigamSettings__ModelSourceControlLocation:-/workspaces/origam/model-tests/model}
+      - ExternalDomain_SetOnStart=https://localhost:${FRONTEND_PORT:-5173}
+      - OpenIddictConfig__AccessTokenIssuer=https://localhost:${FRONTEND_PORT:-5173}
     volumes:
       - ..:/workspaces/origam:cached
       - devcontainer-nuget:/root/.nuget/packages
@@ -49,7 +51,7 @@ services:
       dockerfile: ../docker/DockerfileVite.dev
     image: origam/architect-frontend:dev
     ports:
-      - "5174:5173"
+      - "${ARCHITECT_FRONTEND_PORT:-5174}:5173"
     volumes:
       - ../architect-html:/src/frontend-html
     environment:
@@ -66,13 +68,13 @@ services:
       dockerfile: ../docker/DockerfileVite.dev
     image: origam/frontend:dev
     ports:
-      - "5173:5173"
+      - "${FRONTEND_PORT:-5173}:5173"
     volumes:
       - ../frontend-html:/src/frontend-html
     environment:
       - VITE_PROXY_TARGET=http://devcontainer:8080
       - VITE_HOST=0.0.0.0
-      - VITE_OIDC_AUTHORITY=https://localhost:5173
+      - VITE_OIDC_AUTHORITY=https://localhost:${FRONTEND_PORT:-5173}
     depends_on:
       - devcontainer
 

--- a/.devcontainer/netcoredbg-server.sh
+++ b/.devcontainer/netcoredbg-server.sh
@@ -22,7 +22,7 @@ case "$TARGET" in
     DLL="Origam.Server.dll"
     export ASPNETCORE_URLS="http://+:8080"
     # Must match the browser-facing origin or login 401s (ID2088).
-    export OpenIddictConfig__AccessTokenIssuer="https://localhost:5173"
+    export OpenIddictConfig__AccessTokenIssuer="${OpenIddictConfig__AccessTokenIssuer:-https://localhost:5173}"
     BUILD_HINT="bash .devcontainer/debug-build-server.sh"
     ;;
   *)

--- a/.devcontainer/netcoredbg-server.sh
+++ b/.devcontainer/netcoredbg-server.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Launch netcoredbg as a DAP TCP server for any DAP client (nvim-dap, helix,
+# a DAP bridge, an MCP agent) — the editor-agnostic alternative to vsdbg.
+# Build + stage first (the debugger launches the built DLL):
+#   bash .devcontainer/debug-build-architect.sh   # or debug-build-server.sh
+# Then attach to localhost:$PORT (forwarded by devcontainer.json). The launched
+# process inherits cwd + the env below unless the client overrides them.
+
+set -e
+TARGET="${1:-architect}"
+PORT="${PORT:-47000}"
+
+case "$TARGET" in
+  architect)
+    BIN="/workspaces/origam/backend/Origam.Architect.Server/bin/Debug Architect Server/net8.0"
+    DLL="Origam.Architect.Server.dll"
+    export ASPNETCORE_URLS="http://+:8081"
+    BUILD_HINT="bash .devcontainer/debug-build-architect.sh"
+    ;;
+  server)
+    BIN="/workspaces/origam/backend/Origam.Server/bin/Debug/net8.0"
+    DLL="Origam.Server.dll"
+    export ASPNETCORE_URLS="http://+:8080"
+    # Must match the browser-facing origin or login 401s (ID2088).
+    export OpenIddictConfig__AccessTokenIssuer="https://localhost:5173"
+    BUILD_HINT="bash .devcontainer/debug-build-server.sh"
+    ;;
+  *)
+    echo "Usage: $0 [architect|server]" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$BIN/$DLL" ]; then
+  echo "Build first: $BUILD_HINT" >&2
+  exit 1
+fi
+
+# cwd = bin = content root (appsettings.json / log4net.config live here).
+cd "$BIN"
+exec netcoredbg --interpreter=vscode --server="$PORT" \
+  -- "$(command -v dotnet)" "$BIN/$DLL"

--- a/.devcontainer/run-architect.sh
+++ b/.devcontainer/run-architect.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Build + run Origam.Architect.Server from source (devcontainer).
+# The architect doesn't deploy the DB schema on a fresh database — run the
+# runtime server once first (it deploys the schema), e.g.:
+#   docker compose up server database
+# To debug instead of run, see netcoredbg-server.sh.
+
+set -e
+cd /workspaces/origam/backend
+
+CONFIG="${CONFIG:-Debug Architect Server}"
+
+dotnet build Origam.Architect.Server/Origam.Architect.Server.csproj \
+    /p:Configuration="$CONFIG" -v:minimal
+
+# Run from bin: content root = cwd, where the app reads appsettings.json /
+# log4net.config; OrigamSettings.config sits next to the DLL.
+BIN="Origam.Architect.Server/bin/$CONFIG/net8.0"
+
+cp ../docker/server/_OrigamSettings.template "$BIN/OrigamSettings.config"
+source ../docker/server/linux/fill_origam_settings_config.sh
+fill_origam_settings_config "$BIN/OrigamSettings.config" "${DatabaseType}"
+
+cp ../docker/dev/appsettings.architect.json "$BIN/appsettings.json"
+cp ../docker/dev/log4net.config "$BIN/log4net.config"
+mkdir -p "$BIN/ClientApplication"
+
+cd "$BIN"
+export ASPNETCORE_URLS="http://+:8081"
+exec dotnet Origam.Architect.Server.dll

--- a/.devcontainer/run-server.sh
+++ b/.devcontainer/run-server.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Build + run Origam.Server from source (devcontainer, no debugger).
+# For debugging, use the F5 launch config.
+set -e
+cd /workspaces/origam/backend
+
+CONFIG="${CONFIG:-Debug Server}"
+dotnet build Origam.Server/Origam.Server.csproj /p:Configuration="$CONFIG" -v:minimal
+
+# The Server csproj flattens OutputPath to bin\<first word of Configuration>\,
+# so "Debug Server" lands in bin/Debug/, not bin/Debug Server/.
+BIN="Origam.Server/bin/${CONFIG%% *}/net8.0"
+
+EXTERNAL_DOMAIN="${ExternalDomain_SetOnStart:-https://localhost:5173}"
+cp ../docker/server/_appsettings.template "$BIN/appsettings.json"
+sed -i "s|ExternalDomain|${EXTERNAL_DOMAIN}|g" "$BIN/appsettings.json"
+# Match configureServer.sh's chat substitutions + fix the template's trailing
+# comma after ServerClient.ClientSecret.
+sed -i "s|pathchatapp||" "$BIN/appsettings.json"
+sed -i "s|chatinterval|0|" "$BIN/appsettings.json"
+sed -i "/serverSecret/s/,$//" "$BIN/appsettings.json"
+
+cp ../docker/server/_OrigamSettings.template "$BIN/OrigamSettings.config"
+source ../docker/server/linux/fill_origam_settings_config.sh
+fill_origam_settings_config "$BIN/OrigamSettings.config" "${DatabaseType}"
+
+cp ../docker/dev/log4net.config "$BIN/log4net.config"
+mkdir -p /home/origam/server_bin/clients/origam
+
+cd "$BIN"
+export ASPNETCORE_URLS="http://+:8080"
+exec dotnet Origam.Server.dll

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Docker build context hygiene — keeps `docker build` from sending churn.
+# (Build context is already small; this is preventive.)
+
+# Build artifacts
+**/bin/
+**/obj/
+**/node_modules/
+**/dist/
+**/.vite/
+
+# Test artifacts / data
+model-tests/**/TestResults/
+**/*.TestResults/
+
+# Logs
+**/logs/
+**/*.log
+
+# IDE / OS
+.vs/
+.idea/
+**/.DS_Store
+
+# Docker dev-local files (gitignored anyway, but keep out of context)
+docker/dev/.env
+docker-compose.override.yml
+
+# Git
+.git/

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ RuntimeModelConfiguration.json
 /docker/debug/model-test_Linux.env
 /docker/debug/model-test_Windows.cmd
 /docker/debug/model-test_Windows.env
+/docker/dev/.env
+/.devcontainer/.env
+/docker-compose.override.yml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,8 +25,7 @@
             "cwd": "${workspaceFolder}/backend/Origam.Server/bin/Debug/net8.0",
             "stopAtEntry": false,
             "env": {
-                "ASPNETCORE_URLS": "http://+:8080",
-                "OpenIddictConfig__AccessTokenIssuer": "https://localhost:5173"
+                "ASPNETCORE_URLS": "http://+:8080"
             },
             "console": "internalConsole"
         }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Architect.Server",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-architect",
+            "program": "${workspaceFolder}/backend/Origam.Architect.Server/bin/Debug Architect Server/net8.0/Origam.Architect.Server.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/backend/Origam.Architect.Server/bin/Debug Architect Server/net8.0",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_URLS": "http://+:8081"
+            },
+            "console": "internalConsole"
+        },
+        {
+            "name": "Debug Origam.Server",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-server",
+            "program": "${workspaceFolder}/backend/Origam.Server/bin/Debug/net8.0/Origam.Server.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/backend/Origam.Server/bin/Debug/net8.0",
+            "stopAtEntry": false,
+            "env": {
+                "ASPNETCORE_URLS": "http://+:8080",
+                "OpenIddictConfig__AccessTokenIssuer": "https://localhost:5173"
+            },
+            "console": "internalConsole"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-architect",
+            "type": "shell",
+            "command": "bash .devcontainer/debug-build-architect.sh",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build-server",
+            "type": "shell",
+            "command": "bash .devcontainer/debug-build-server.sh",
+            "problemMatcher": "$msCompile",
+            "group": { "kind": "build", "isDefault": true }
+        }
+    ]
+}

--- a/HOWTOSTART.md
+++ b/HOWTOSTART.md
@@ -12,6 +12,26 @@ It is also possible to download the compiled server application
 [here](https://github.com/origam/origam/releases) and just build and debug the 
 client application. 
 
+## Running in Docker (alternative to the Windows setup)
+If you don't want to set up Windows, Visual Studio, and a local SQL Server, you
+can run the whole stack (SQL Server + backend + frontend dev server) in Docker.
+It builds the backend from source and runs the frontend via Vite (hot reload),
+against the bundled demo model. Linux, macOS, and Windows hosts all work.
+
+```bash
+docker compose up -d
+```
+
+The app is then at `https://localhost:5173`. See
+[`docker/dev/README.md`](docker/dev/README.md) for details, including how to
+point the stack at your own model instead of the demo.
+
+For editing and debugging the backend with breakpoints, use the devcontainer
+instead — it works in VS Code, Cursor, Rider, and other editors. See
+[`.devcontainer/README.md`](.devcontainer/README.md).
+
+The rest of this guide covers the Windows/Visual Studio setup.
+
 ## Download Software
 Here is what you have to install first. Make sure you have at least 50 GB of free 
 space on you hard drive before you install all the software. That way you should still have enough space to build origam 

--- a/architect-html/vite.config.ts
+++ b/architect-html/vite.config.ts
@@ -10,6 +10,9 @@ import mkcert from 'vite-plugin-mkcert';
 // Local development keeps HTTPS by default.
 const httpsDisabled = process.env.VITE_DISABLE_HTTPS === 'true';
 
+const proxyTargetHttps = process.env.VITE_ARCHITECT_PROXY_TARGET_HTTPS ?? 'https://localhost:7099';
+const proxyTargetHttp = process.env.VITE_ARCHITECT_PROXY_TARGET_HTTP ?? 'http://localhost:5003';
+
 export default defineConfig({
   define: {
     __ORIGAM_ARCHITECT_HTML_VERSION__: JSON.stringify(
@@ -48,59 +51,59 @@ export default defineConfig({
     ...(httpsDisabled ? {} : { https: {} }),
     proxy: {
       '/Model': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/Package': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/Tab': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/Test': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/ScreenEditor': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/SectionEditor': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/PropertyEditor': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/Documentation': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/Xslt': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
       '/Icons': {
-        target: 'http://localhost:5003',
+        target: proxyTargetHttp,
         secure: false,
       },
       '/DeploymentScripts': {
-        target: 'http://localhost:5003',
+        target: proxyTargetHttp,
         secure: false,
       },
       '/DeploymentScriptsGenerator': {
-        target: 'http://localhost:5003',
+        target: proxyTargetHttp,
         secure: false,
       },
       '/Search': {
-        target: 'http://localhost:5003',
+        target: proxyTargetHttp,
         secure: false,
       },
       '/wizards': {
-        target: 'https://localhost:7099',
+        target: proxyTargetHttps,
         secure: false,
       },
     },

--- a/backend/Directory.Build.targets
+++ b/backend/Directory.Build.targets
@@ -1,5 +1,16 @@
 <Project>
   <!--
+    The "... Architect Server" configs define ORIGAM_SERVER so ReflectorCache
+    excludes Origam.Gui.Win (net472/WinForms, unbuildable on the Linux SDK ->
+    NETSDK1136). ORIGAM_CLIENT is intentionally left undefined so
+    MetaModelUpgradeMode stays "Upgrade" (needed by the model editor). Both
+    Debug and Release so dev/debug builds work.
+  -->
+  <PropertyGroup Condition="$(Configuration.EndsWith('Architect Server'))">
+    <DefineConstants>$(DefineConstants);ORIGAM_SERVER</DefineConstants>
+  </PropertyGroup>
+
+  <!--
     For legacy non-SDK csproj files (those that contain TargetFrameworkVersion),
     Directory.Build.props sets DisableMeziantouAnalyzer=true and skips the
     Meziantou.Analyzer PackageReference. 

--- a/backend/Origam.DA.Service/AbstractSqlDataService.cs
+++ b/backend/Origam.DA.Service/AbstractSqlDataService.cs
@@ -131,6 +131,10 @@ internal class DataLoader
             }
             catch (Exception ex)
             {
+                if (ex is SqlException sqlEx && sqlEx.Number == 208)
+                {
+                    throw new Origam.DA.DatabaseTableNotFoundException(Entity.Name, sqlEx);
+                }
                 HandleException(
                     exception: ex,
                     commandText: dbDataAdapter.SelectCommand.CommandText,

--- a/docker-compose.architect.yml
+++ b/docker-compose.architect.yml
@@ -14,7 +14,7 @@ services:
       - DatabaseType=mssql
       - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
       - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
-      - OrigamSettings__DataConnectionString=Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${SA_PASSWORD:-Origam@Dev123};
+      - OrigamSettings__DataConnectionString=Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${MSSQL_SA_PASSWORD:-};
       - OrigamSettings__ModelSourceControlLocation=/home/origam/projectData/model
       - TZ=Europe/Prague
     ports:

--- a/docker-compose.architect.yml
+++ b/docker-compose.architect.yml
@@ -18,7 +18,7 @@ services:
       - OrigamSettings__ModelSourceControlLocation=/home/origam/projectData/model
       - TZ=Europe/Prague
     ports:
-      - "8081:8081"
+      - "${ARCHITECT_PORT:-8081}:8081"
     entrypoint: ["/bin/bash", "/home/origam/architect_bin/entrypoint.architect.sh"]
     volumes:
       - ./model-tests/model:/home/origam/projectData/model
@@ -38,7 +38,7 @@ services:
       dockerfile: ../docker/DockerfileVite.dev
     image: origam/architect-frontend:dev
     ports:
-      - "5174:5173"
+      - "${ARCHITECT_FRONTEND_PORT:-5174}:5173"
     volumes:
       - ./architect-html:/src/frontend-html
     environment:

--- a/docker-compose.architect.yml
+++ b/docker-compose.architect.yml
@@ -1,0 +1,52 @@
+# Add the HTML Architect (the modeler): Origam.Architect.Server + a Vite dev
+# server for architect-html. Shares the DB + model with the runtime server.
+# Opt-in (not started by `docker compose up`):
+#   docker compose -f docker-compose.yml -f docker-compose.architect.yml up -d
+# Architect frontend: https://localhost:5174 (self-signed cert)  API: :8081
+
+services:
+  architect:
+    build:
+      context: .
+      dockerfile: docker/DockerfileArchitect.dev
+    image: origam/architect:dev
+    environment:
+      - DatabaseType=mssql
+      - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
+      - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
+      - OrigamSettings__DataConnectionString=Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${SA_PASSWORD:-Origam@Dev123};
+      - OrigamSettings__ModelSourceControlLocation=/home/origam/projectData/model
+      - TZ=Europe/Prague
+    ports:
+      - "8081:8081"
+    entrypoint: ["/bin/bash", "/home/origam/architect_bin/entrypoint.architect.sh"]
+    volumes:
+      - ./model-tests/model:/home/origam/projectData/model
+      - ./docker/dev/entrypoint.architect.sh:/home/origam/architect_bin/entrypoint.architect.sh
+      - ./docker/dev/appsettings.architect.json:/home/origam/architect_bin/appsettings.json
+      - origam-dataprotection:/home/origam/.aspnet/DataProtection-Keys
+    depends_on:
+      database:
+        condition: service_healthy
+      # Architect does not deploy the schema on a fresh DB; the server must run first.
+      server:
+        condition: service_healthy
+
+  architect-frontend:
+    build:
+      context: ./architect-html
+      dockerfile: ../docker/DockerfileVite.dev
+    image: origam/architect-frontend:dev
+    ports:
+      - "5174:5173"
+    volumes:
+      - ./architect-html:/src/frontend-html
+    environment:
+      - VITE_ARCHITECT_PROXY_TARGET_HTTPS=http://architect:8081
+      - VITE_ARCHITECT_PROXY_TARGET_HTTP=http://architect:8081
+      - VITE_HOST=0.0.0.0
+      # No auth → no Secure cookies; serve HTTP and avoid vite-plugin-mkcert's
+      # update-ca-certificates dep (absent in node:24-slim).
+      - VITE_DISABLE_HTTPS=true
+    depends_on:
+      - architect

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,11 @@
+# Personal override (gitignored). docker compose auto-loads
+# docker-compose.override.yml on top of docker-compose.yml. Use it to point the
+# stack at your own model. Copy this file to docker-compose.override.yml to use.
+
+services:
+  server:
+    volumes:
+      - ./path/to/your/model:/home/origam/projectData/model
+    environment:
+      # Must match your model's root package id.
+      - OrigamSettings__DefaultSchemaExtensionId=00000000-0000-0000-0000-000000000000

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -18,13 +18,13 @@ services:
       start_period: 30s
     environment: !override
       POSTGRES_USER: "${POSTGRES_USER:-origam}"
-      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-Origam@Dev123}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-}"
       POSTGRES_DB: "${POSTGRES_DB:-origam}"
 
   server:
     environment:
       - DatabaseType=postgresql
-      - OrigamSettings__DataConnectionString=sslmode=disable;Application Name=Origam;Host=database;Port=5432;Username=${POSTGRES_USER:-origam};Password=${POSTGRES_PASSWORD:-Origam@Dev123};Database=${POSTGRES_DB:-origam};Pooling=True;Search Path=${POSTGRES_DB:-origam},public
+      - OrigamSettings__DataConnectionString=sslmode=disable;Application Name=Origam;Host=database;Port=5432;Username=${POSTGRES_USER:-origam};Password=${POSTGRES_PASSWORD:-};Database=${POSTGRES_DB:-origam};Pooling=True;Search Path=${POSTGRES_DB:-origam},public
 
 volumes:
   origam-postgres-data:

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,30 @@
+# Swap SQL Server for PostgreSQL. Run with both files:
+#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+# Postgres creates the DB/user from env; Origam's deployment creates the schema.
+
+services:
+  database:
+    image: postgres:16
+    entrypoint: !reset []
+    ports: !override
+      - "5432:5432"
+    volumes: !override
+      - origam-postgres-data:/var/lib/postgresql/data
+    healthcheck: !override
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-origam} -d ${POSTGRES_DB:-origam}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    environment: !override
+      POSTGRES_USER: "${POSTGRES_USER:-origam}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-Origam@Dev123}"
+      POSTGRES_DB: "${POSTGRES_DB:-origam}"
+
+  server:
+    environment:
+      - DatabaseType=postgresql
+      - OrigamSettings__DataConnectionString=sslmode=disable;Application Name=Origam;Host=database;Port=5432;Username=${POSTGRES_USER:-origam};Password=${POSTGRES_PASSWORD:-Origam@Dev123};Database=${POSTGRES_DB:-origam};Pooling=True;Search Path=${POSTGRES_DB:-origam},public
+
+volumes:
+  origam-postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,16 @@
 # ORIGAM development stack: database + .NET backend (built from backend/) +
-# Vite dev server. Defaults work with no .env; override via docker/dev/.env.
+# Vite dev server. The DB password is NOT baked in — set it in docker/dev/.env
+# (copy from docker/dev/.env.example). ps/logs/config/build run without it; only
+# `up` needs it (the DB won't start without a password):
 #
-#   docker compose up -d
-#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
-#   docker compose build server                   # rebuild after C# changes
+#   docker compose --env-file docker/dev/.env up -d
+#   docker compose --env-file docker/dev/.env -f docker-compose.yml -f docker-compose.postgres.yml up -d
+#   docker compose build server                   # rebuild after C# changes (no --env-file needed)
 #
 # App:             https://localhost:5173 (self-signed cert)
 # Backend/Swagger: http://localhost:8080
-# SQL Server:      localhost:1433 (sa / Origam@Dev123)
-# PostgreSQL:      localhost:5432 (origam / Origam@Dev123)
+# SQL Server:      localhost:1433 (sa — password in docker/dev/.env)
+# PostgreSQL:      localhost:5432 (origam — password in docker/dev/.env)
 
 name: origam-dev
 
@@ -17,7 +19,7 @@ services:
     image: mcr.microsoft.com/mssql/server:2019-latest
     environment:
       ACCEPT_EULA: "Y"
-      SA_PASSWORD: "${SA_PASSWORD:-Origam@Dev123}"
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD:-}"
       MSSQL_AGENT_ENABLED: "true"
     ports:
       - "1433:1433"
@@ -29,7 +31,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD:-Origam@Dev123}" -C -Q ''SELECT 1'' || exit 1',
+          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${MSSQL_SA_PASSWORD:-}" -C -Q ''SELECT 1'' || exit 1',
         ]
       interval: 10s
       timeout: 5s
@@ -49,7 +51,7 @@ services:
       - OpenIddictConfig__AccessTokenIssuer=https://localhost:5173
       - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
       - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
-      - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${SA_PASSWORD:-Origam@Dev123};}
+      - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${MSSQL_SA_PASSWORD:-};}
       - OrigamSettings__ModelSourceControlLocation=${OrigamSettings__ModelSourceControlLocation:-/home/origam/projectData/model}
       - TZ=Europe/Prague
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD:-}"
       MSSQL_AGENT_ENABLED: "true"
     ports:
-      - "1433:1433"
+      - "${MSSQL_PORT:-1433}:1433"
     volumes:
       - origam-db-data:/var/opt/mssql
       - ./docker/dev/initdb:/docker-entrypoint-initdb.d:ro
@@ -47,15 +47,15 @@ services:
     image: origam/server:dev
     environment:
       - DatabaseType=mssql
-      - ExternalDomain_SetOnStart=https://localhost:5173
-      - OpenIddictConfig__AccessTokenIssuer=https://localhost:5173
+      - ExternalDomain_SetOnStart=https://localhost:${FRONTEND_PORT:-5173}
+      - OpenIddictConfig__AccessTokenIssuer=https://localhost:${FRONTEND_PORT:-5173}
       - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
       - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
       - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${MSSQL_SA_PASSWORD:-};}
       - OrigamSettings__ModelSourceControlLocation=${OrigamSettings__ModelSourceControlLocation:-/home/origam/projectData/model}
       - TZ=Europe/Prague
     ports:
-      - "8080:8080"
+      - "${SERVER_PORT:-8080}:8080"
     entrypoint: ["/bin/bash", "/home/origam/server_bin/entrypoint.dev.sh"]
     volumes:
       - ./model-tests/model:/home/origam/projectData/model
@@ -83,14 +83,14 @@ services:
       dockerfile: ../docker/DockerfileVite.dev
     image: origam/frontend:dev
     ports:
-      - "5173:5173"
+      - "${FRONTEND_PORT:-5173}:5173"
     volumes:
       - ./frontend-html:/src/frontend-html
     environment:
       - VITE_PROXY_TARGET=http://server:8080
       - VITE_HOST=0.0.0.0
       # OIDC endpoints are proxied through Vite, so the authority is the SPA origin.
-      - VITE_OIDC_AUTHORITY=https://localhost:5173
+      - VITE_OIDC_AUTHORITY=https://localhost:${FRONTEND_PORT:-5173}
     depends_on:
       - server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,97 @@
+# ORIGAM development stack: database + .NET backend (built from backend/) +
+# Vite dev server. Defaults work with no .env; override via docker/dev/.env.
+#
+#   docker compose up -d
+#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+#   docker compose build server                   # rebuild after C# changes
+#
+# App:             https://localhost:5173 (self-signed cert)
+# Backend/Swagger: http://localhost:8080
+# SQL Server:      localhost:1433 (sa / Origam@Dev123)
+# PostgreSQL:      localhost:5432 (origam / Origam@Dev123)
+
+name: origam-dev
+
+services:
+  database:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: "${SA_PASSWORD:-Origam@Dev123}"
+      MSSQL_AGENT_ENABLED: "true"
+    ports:
+      - "1433:1433"
+    volumes:
+      - origam-db-data:/var/opt/mssql
+      - ./docker/dev/initdb:/docker-entrypoint-initdb.d:ro
+    entrypoint: ["/bin/bash", "/docker-entrypoint-initdb.d/run-init.sh"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          '/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD:-Origam@Dev123}" -C -Q ''SELECT 1'' || exit 1',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+  # PostgreSQL database (opt-in). See docker-compose.postgres.yml.
+
+  server:
+    build:
+      context: .
+      dockerfile: docker/DockerfileServer.dev
+    image: origam/server:dev
+    environment:
+      - DatabaseType=mssql
+      - ExternalDomain_SetOnStart=https://localhost:5173
+      - OpenIddictConfig__AccessTokenIssuer=https://localhost:5173
+      - OrigamSettings__Name=${OrigamSettings__Name:-DevProject}
+      - OrigamSettings__DefaultSchemaExtensionId=${OrigamSettings__DefaultSchemaExtensionId:-f17329d6-3143-420a-a2e6-30e431eea51d}
+      - OrigamSettings__DataConnectionString=${OrigamSettings__DataConnectionString:-Encrypt=False;Data Source=database,1433;Initial Catalog=origam-dev;User ID=sa;Password=${SA_PASSWORD:-Origam@Dev123};}
+      - OrigamSettings__ModelSourceControlLocation=${OrigamSettings__ModelSourceControlLocation:-/home/origam/projectData/model}
+      - TZ=Europe/Prague
+    ports:
+      - "8080:8080"
+    entrypoint: ["/bin/bash", "/home/origam/server_bin/entrypoint.dev.sh"]
+    volumes:
+      - ./model-tests/model:/home/origam/projectData/model
+      - ./docker/dev/entrypoint.dev.sh:/home/origam/server_bin/entrypoint.dev.sh
+      - ./docker/dev/log4net.config:/home/origam/server_bin/log4net.config
+      # Persist the Data Protection key ring (auth cookies break on recreate otherwise).
+      - origam-dataprotection:/home/origam/.aspnet/DataProtection-Keys
+    depends_on:
+      database:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -o /dev/null http://localhost:8080/ || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+
+  frontend:
+    build:
+      context: ./frontend-html
+      dockerfile: ../docker/DockerfileVite.dev
+    image: origam/frontend:dev
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend-html:/src/frontend-html
+    environment:
+      - VITE_PROXY_TARGET=http://server:8080
+      - VITE_HOST=0.0.0.0
+      # OIDC endpoints are proxied through Vite, so the authority is the SPA origin.
+      - VITE_OIDC_AUTHORITY=https://localhost:5173
+    depends_on:
+      - server
+
+volumes:
+  origam-db-data:
+  origam-dataprotection:

--- a/docker/DockerfileArchitect.dev
+++ b/docker/DockerfileArchitect.dev
@@ -1,0 +1,67 @@
+# ORIGAM Architect Server — development image for the HTML modeler backend.
+# The architect-html frontend runs separately via DockerfileVite.dev
+# (see docker-compose.architect.yml).
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+WORKDIR /src
+
+COPY backend/ /src/backend/
+
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet restore backend/Origam.sln
+
+RUN dotnet build backend/Origam.Architect.Server/Origam.Architect.Server.csproj \
+    /p:Configuration="Release Architect Server" -v:minimal
+
+# `dotnet publish -o` fails to copy satellite culture dirs for this project
+# graph (not dotnet/sdk#26711, not a race, trailing slash doesn't help; the
+# Server graph publishes fine). The build output is already a complete layout
+# with satellites, so stage it with plain cp.
+RUN mkdir -p /out \
+ && cp -r "backend/Origam.Architect.Server/bin/Release Architect Server/net8.0" /out/architect
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+WORKDIR /tmp
+
+# libgdiplus from source (System.Drawing for reporting); same as DockerfileServer.dev.
+RUN apt-get update \
+ && apt-get -y install ca-certificates curl sudo git make g++ xmlstarlet \
+ && apt-get -y install libgif-dev autoconf libtool automake gettext \
+    libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev libpango1.0-dev \
+ && git clone --depth 1 https://github.com/mono/libgdiplus.git /tmp/libgdiplus \
+ && cd libgdiplus \
+ && ./autogen.sh --with-pango --prefix=/usr \
+ && make && make install \
+ && cd .. && rm -rf libgdiplus \
+ && apt-get -y purge autoconf automake libtool \
+ && apt-get -y autoremove
+
+RUN useradd -ms /bin/bash origam \
+ && usermod -aG sudo origam \
+ && echo "%sudo   ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+WORKDIR /home/origam
+
+RUN mkdir -p architect_bin ClientApplication Setup \
+ && chown -R origam:origam /home/origam
+
+COPY --chown=origam:origam --from=build /out/architect /home/origam/architect_bin/
+
+COPY --chown=origam:origam docker/server/linux/fill_origam_settings_config.sh \
+     docker/server/_OrigamSettings.template \
+     docker/shared/linux/bootstrap.sh \
+     /home/origam/architect_bin/
+
+COPY --chown=origam:origam docker/dev/appsettings.architect.json \
+     /home/origam/architect_bin/appsettings.json
+
+# AddLog4Net() hard-requires log4net.config in the content root; the build
+# output only ships ConfigTemplates/_log4net.config.
+COPY --chown=origam:origam docker/dev/log4net.config \
+     /home/origam/architect_bin/log4net.config
+
+WORKDIR /home/origam/architect_bin
+
+ENTRYPOINT ["/bin/bash", "-c", "./entrypoint.sh"]

--- a/docker/DockerfileServer.dev
+++ b/docker/DockerfileServer.dev
@@ -1,0 +1,92 @@
+# ORIGAM Server — development image. Builds the .NET backend from source; the
+# frontend runs separately via DockerfileVite.dev. No nginx/TLS — the Vite dev
+# server proxies straight to :8080 (see docker/dev/README.md).
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+WORKDIR /src
+
+COPY backend/ /src/backend/
+
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet restore backend/Origam.sln
+
+# net472 projects can't compile on the Linux SDK, so build only the net8.0
+# server + scheduler targets.
+RUN dotnet build backend/Origam.Server/Origam.Server.csproj \
+    /p:Configuration="Release Server" -v:minimal && \
+    dotnet build backend/OrigamScheduler/OrigamScheduler.csproj \
+    /p:Configuration="Release Server" -v:minimal
+
+# Publish server
+RUN dotnet publish backend/Origam.Server/Origam.Server.csproj \
+    /p:Configuration="Release Server" \
+    -o /out/server
+
+# Publish scheduler
+RUN dotnet publish backend/OrigamScheduler/OrigamScheduler.csproj \
+    /p:Configuration="Release Server" \
+    -o /out/scheduler
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+WORKDIR /tmp
+
+# libgdiplus from source: fixes international-character rendering in FastReport
+# (same reason as DockerfileServer.linux).
+RUN apt-get update \
+ && apt-get -y install ca-certificates curl sudo git make g++ xmlstarlet \
+ && apt-get -y install libgif-dev autoconf libtool automake gettext \
+    libglib2.0-dev libcairo2-dev libtiff-dev libexif-dev libpango1.0-dev \
+ && git clone --depth 1 https://github.com/mono/libgdiplus.git /tmp/libgdiplus \
+ && cd libgdiplus \
+ && ./autogen.sh --with-pango --prefix=/usr \
+ && make && make install \
+ && cd .. && rm -rf libgdiplus \
+ && apt-get -y purge autoconf automake libtool \
+ && apt-get -y autoremove
+
+RUN useradd -ms /bin/bash origam \
+ && usermod -aG sudo origam \
+ && echo "%sudo   ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+WORKDIR /home/origam
+
+RUN mkdir -p server_bin client_source scheduler_bin Setup \
+ && chown -R origam:origam /home/origam
+
+COPY --chown=origam:origam --from=build /out/server /home/origam/server_bin/
+COPY --chown=origam:origam --from=build /out/scheduler /home/origam/scheduler_bin/
+
+COPY --chown=origam:origam docker/server/linux/configureServer.sh \
+     docker/server/linux/fill_origam_settings_config.sh \
+     docker/server/linux/entrypoint.sh \
+     docker/shared/linux/bootstrap.sh \
+     docker/server/log4net.server.config \
+     docker/server/_appsettings.template \
+     docker/server/_OrigamSettings.template \
+     /home/origam/server_bin/
+
+COPY --chown=origam:origam docker/server/linux/configureScheduler.sh \
+     docker/server/linux/fill_origam_settings_config.sh \
+     docker/server/log4net.scheduler.config \
+     /home/origam/scheduler_bin/
+
+RUN mv /home/origam/server_bin/log4net.server.config /home/origam/server_bin/log4net.config \
+ && mv /home/origam/scheduler_bin/log4net.scheduler.config /home/origam/scheduler_bin/log4net.config
+
+# Used by the production entrypoint copied below; harmless when unused.
+COPY --chown=origam:origam docker/server/linux/cleanUpEnvironment.sh \
+     docker/server/linux/cleanUpEnvironmentRoot.sh \
+     /home/origam/Setup/
+
+RUN cd /home/origam/server_bin && mkdir -p logs \
+ && chmod +x configureServer.sh fill_origam_settings_config.sh entrypoint.sh \
+ && cd /home/origam/scheduler_bin && chmod +x configureScheduler.sh fill_origam_settings_config.sh \
+ && cd /home/origam/Setup && chmod +x cleanUpEnvironment.sh cleanUpEnvironmentRoot.sh
+
+USER origam
+
+WORKDIR /home/origam/server_bin
+
+ENTRYPOINT ["/bin/bash", "-c", "./entrypoint.sh"]

--- a/docker/DockerfileVite.dev
+++ b/docker/DockerfileVite.dev
@@ -1,0 +1,14 @@
+# Vite dev server for frontend-html. Source is bind-mounted at runtime, so
+# dependencies install on start (into the mounted node_modules), not at build.
+
+FROM node:24-slim
+
+WORKDIR /src/frontend-html
+
+# corepack + classic node-modules linker (the toolchain expects a real tree).
+RUN corepack enable \
+ && yarn config set nodeLinker node-modules
+
+EXPOSE 5173
+
+CMD ["sh", "-c", "yarn install --immutable && yarn dev --host 0.0.0.0"]

--- a/docker/dev/.env.example
+++ b/docker/dev/.env.example
@@ -22,3 +22,13 @@ OrigamSettings__Name=DevProject
 # Root schema extension (package) id of the model mounted into the server.
 # f17329d6-... is the root package of the test model at model-tests/model.
 OrigamSettings__DefaultSchemaExtensionId=f17329d6-3143-420a-a2e6-30e431eea51d
+
+# Host ports — override only if the defaults conflict with another stack on the
+# same host. Container ports stay fixed; only the host mapping moves.
+# FRONTEND_PORT also drives OIDC (ExternalDomain / AccessTokenIssuer /
+# VITE_OIDC_AUTHORITY) so login works on the remapped port.
+# MSSQL_PORT=1433
+# SERVER_PORT=8080
+# FRONTEND_PORT=5173
+# ARCHITECT_PORT=8081
+# ARCHITECT_FRONTEND_PORT=5174

--- a/docker/dev/.env.example
+++ b/docker/dev/.env.example
@@ -1,0 +1,16 @@
+# Optional overrides. docker-compose.yml bakes in defaults, so this file is
+# only needed to change them. Kept under docker/dev/ (not the repo root) so
+# non-Docker tooling that reads a root .env doesn't pick it up.
+#
+#   docker compose --env-file docker/dev/.env up
+
+# SQL Server `sa` password. Must meet SQL Server policy (8+ chars, upper/lower/digit).
+# Used by the database container, the init script, and the backend connection string.
+SA_PASSWORD=Origam@Dev123
+
+# Project name (shown in the app / used for model identification).
+OrigamSettings__Name=DevProject
+
+# Root schema extension (package) id of the model mounted into the server.
+# f17329d6-... is the root package of the test model at model-tests/model.
+OrigamSettings__DefaultSchemaExtensionId=f17329d6-3143-420a-a2e6-30e431eea51d

--- a/docker/dev/.env.example
+++ b/docker/dev/.env.example
@@ -1,12 +1,20 @@
-# Optional overrides. docker-compose.yml bakes in defaults, so this file is
-# only needed to change them. Kept under docker/dev/ (not the repo root) so
-# non-Docker tooling that reads a root .env doesn't pick it up.
+# Copy to .env (gitignored) and fill in. The DB password is NOT baked into the
+# compose files — `up` reads it from here via --env-file (ps/logs/config/build
+# run without it). Kept under docker/dev/ (not the repo root) so non-Docker
+# tooling that reads a root .env doesn't pick it up.
 #
-#   docker compose --env-file docker/dev/.env up
+#   docker compose --env-file docker/dev/.env up -d
 
 # SQL Server `sa` password. Must meet SQL Server policy (8+ chars, upper/lower/digit).
-# Used by the database container, the init script, and the backend connection string.
-SA_PASSWORD=Origam@Dev123
+# Used by the database container, the healthcheck, and the backend connection string.
+# MUST match the password the origam-db-data volume was initialized with — MSSQL
+# only honors MSSQL_SA_PASSWORD on first init, so changing this alone does NOT re-set an
+# existing database's sa password (needs `docker compose down -v` + restart).
+MSSQL_SA_PASSWORD=Origam@Dev123
+
+# PostgreSQL password (only used with docker-compose.postgres.yml). Same first-init
+# caveat as MSSQL_SA_PASSWORD (origam-postgres-data volume).
+POSTGRES_PASSWORD=Origam@Dev123
 
 # Project name (shown in the app / used for model identification).
 OrigamSettings__Name=DevProject

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -1,0 +1,107 @@
+# Origam Local Development Environment
+
+Builds and runs the Origam backend from source alongside a database (SQL Server
+by default, PostgreSQL optional) and a Vite dev server for `frontend-html`.
+The compose file lives at the **repository root** (`docker-compose.yml`);
+this directory holds the supporting files (entrypoint, DB init scripts, env
+overrides, log4net config).
+
+## Quick Start
+
+```bash
+# From the repository root:
+docker compose up -d
+
+# First run builds the backend image (a few minutes). Subsequent starts reuse
+# the built image and are fast.
+
+# Frontend (the app):    https://localhost:5173  (accept the self-signed cert)
+# Backend API / Swagger: http://localhost:8080
+# SQL Server:            localhost:1433          (sa / Origam@Dev123)
+```
+
+No `.env` file is required — defaults are baked into the compose file. To
+override values, copy `docker/dev/.env.example` to `docker/dev/.env`, edit it,
+and start with:
+
+```bash
+docker compose --env-file docker/dev/.env up
+```
+
+## Services
+
+| Service  | Image                      | Port  | Notes                                            |
+|----------|----------------------------|-------|--------------------------------------------------|
+| database | mcr.microsoft.com/mssql/server:2019-latest | 1433 | SQL Server; bootstraps `origam-dev` DB on first start |
+| server   | origam/server:dev (built)  | 8080  | .NET backend, built from `backend/`              |
+| frontend | origam/frontend:dev (built)| 5173  | Vite dev server for `frontend-html` (HMR)        |
+
+The server runs the published `Origam.Server.dll` (no nginx in dev). The Vite
+dev server proxies API/auth paths (`/internalApi`, `/connect`, `/Account`, …)
+to `http://server:8080`.
+
+## Model
+
+The bundled demo model (`model-tests/model`) is mounted by default. It is the
+Origam demo project — used for automated testing, so it has lots of features to
+poke at.
+
+To point the stack at your own model, use a compose override (do **not** edit
+`docker-compose.yml` directly — it is committed):
+
+```bash
+cp docker-compose.override.yml.example docker-compose.override.yml
+# edit the model path and OrigamSettings__DefaultSchemaExtensionId (your root package id)
+docker compose up
+```
+
+`docker-compose.override.yml` is gitignored; `docker compose up` auto-merges it
+on top of the committed `docker-compose.yml`. Verify the merged config with
+`docker compose config`.
+
+`SA_PASSWORD` and the DB connection string are also `${VAR:-default}` and can go
+in `docker/dev/.env`; a model swap needs the override file above because it also
+changes the bind mount.
+
+## Login
+
+The database starts empty (no users). Create the initial admin via the app's
+built-in bootstrap endpoint: open
+`https://localhost:5173/Account/RegisterInitialUser` and fill the form. It
+creates a super-user, signs you in, and locks itself after one use.
+
+## Rebuilding after source changes
+
+- **Frontend:** no rebuild needed — Vite hot-reloads on save.
+- **Backend (C#):** `docker compose build server` then `docker compose up -d`.
+
+## Databases
+
+SQL Server is the default. To use PostgreSQL instead:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+# Frontend: https://localhost:5173
+# Postgres: localhost:5432  (origam / Origam@Dev123)
+```
+
+The postgres file overrides the `database` service and points the backend at
+it; no other changes needed. The model deploys onto a fresh Postgres DB on
+first boot.
+
+## Useful Commands
+
+```bash
+docker compose logs -f server        # follow backend logs
+docker compose logs -f frontend      # follow Vite logs
+docker compose down                  # stop the stack
+docker compose down -v               # stop and WIPE the database volume
+docker compose exec server bash      # shell into the server container
+```
+
+## Troubleshooting
+
+- **Port conflicts:** change the host-side mapping in `docker-compose.yml`.
+- **Model not loading:** check the mount (`docker compose exec server ls -la
+  /home/origam/projectData/model`) and the server logs. A mismatched
+  `OrigamSettings__DefaultSchemaExtensionId` is the usual cause.

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -10,23 +10,20 @@ overrides, log4net config).
 
 ```bash
 # From the repository root:
-docker compose up -d
+cp docker/dev/.env.example docker/dev/.env   # set the DB password (gitignored)
+docker compose --env-file docker/dev/.env up -d
 
 # First run builds the backend image (a few minutes). Subsequent starts reuse
 # the built image and are fast.
 
 # Frontend (the app):    https://localhost:5173  (accept the self-signed cert)
 # Backend API / Swagger: http://localhost:8080
-# SQL Server:            localhost:1433          (sa / Origam@Dev123)
+# SQL Server:            localhost:1433          (sa — password in docker/dev/.env)
 ```
 
-No `.env` file is required — defaults are baked into the compose file. To
-override values, copy `docker/dev/.env.example` to `docker/dev/.env`, edit it,
-and start with:
-
-```bash
-docker compose --env-file docker/dev/.env up
-```
+The DB password is required (no default is baked in). `up` reads it from
+`docker/dev/.env` via `--env-file`; `ps`/`logs`/`config`/`build` run without it.
+`docker/dev/.env.example` documents the variables; other settings have defaults.
 
 ## Services
 
@@ -59,8 +56,8 @@ docker compose up
 on top of the committed `docker-compose.yml`. Verify the merged config with
 `docker compose config`.
 
-`SA_PASSWORD` and the DB connection string are also `${VAR:-default}` and can go
-in `docker/dev/.env`; a model swap needs the override file above because it also
+`MSSQL_SA_PASSWORD` (and `POSTGRES_PASSWORD` for the postgres stack) are required in
+`docker/dev/.env`; a model swap needs the override file above because it also
 changes the bind mount.
 
 ## Login
@@ -80,9 +77,9 @@ creates a super-user, signs you in, and locks itself after one use.
 SQL Server is the default. To use PostgreSQL instead:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+docker compose --env-file docker/dev/.env -f docker-compose.yml -f docker-compose.postgres.yml up -d
 # Frontend: https://localhost:5173
-# Postgres: localhost:5432  (origam / Origam@Dev123)
+# Postgres: localhost:5432  (origam — password in docker/dev/.env)
 ```
 
 The postgres file overrides the `database` service and points the backend at

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -99,7 +99,7 @@ docker compose exec server bash      # shell into the server container
 ## Troubleshooting
 
 - **`up` fails with "MSSQL_SA_PASSWORD is not set":** you ran `docker compose up` without the password. Copy `docker/dev/.env.example` to `docker/dev/.env` and start with `--env-file docker/dev/.env` (see Quick Start).
-- **Port conflicts:** change the host-side mapping in `docker-compose.yml`.
+- **Port conflicts:** host ports are overridable in `docker/dev/.env` (`MSSQL_PORT`, `SERVER_PORT`, `FRONTEND_PORT`, `ARCHITECT_PORT`, `ARCHITECT_FRONTEND_PORT`); `FRONTEND_PORT` also retunes OIDC so login works on the new port.
 - **Model not loading:** check the mount (`docker compose exec server ls -la
   /home/origam/projectData/model`) and the server logs. A mismatched
   `OrigamSettings__DefaultSchemaExtensionId` is the usual cause.

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -98,6 +98,7 @@ docker compose exec server bash      # shell into the server container
 
 ## Troubleshooting
 
+- **`up` fails with "MSSQL_SA_PASSWORD is not set":** you ran `docker compose up` without the password. Copy `docker/dev/.env.example` to `docker/dev/.env` and start with `--env-file docker/dev/.env` (see Quick Start).
 - **Port conflicts:** change the host-side mapping in `docker-compose.yml`.
 - **Model not loading:** check the mount (`docker compose exec server ls -la
   /home/origam/projectData/model`) and the server logs. A mismatched

--- a/docker/dev/appsettings.architect.json
+++ b/docker/dev/appsettings.architect.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "SpaConfig": {
+    "PathToClientApplication": "/home/origam/ClientApplication"
+  }
+}

--- a/docker/dev/entrypoint.architect.sh
+++ b/docker/dev/entrypoint.architect.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Development entrypoint: run Origam.Architect.Server.dll from architect_bin,
+# against the same DB + model as the runtime server. The architect-html Vite
+# container proxies API requests here.
+
+set -e
+
+# bootstrap.sh is a no-op unless ORIGAM_PROJECT_BOOTSTRAP=true (consumer flow).
+. /home/origam/architect_bin/bootstrap.sh
+
+if [ -z "${OrigamSettings__ModelSourceControlLocation}" ]; then
+  export OrigamSettings__ModelSourceControlLocation="/home/origam/projectData/model"
+fi
+
+# Docker creates named-volume mount points as root; chown so origam can write
+# Data Protection keys.
+sudo chown -R origam:origam /home/origam/.aspnet/DataProtection-Keys 2>/dev/null || true
+
+cd /home/origam/architect_bin
+cp _OrigamSettings.template OrigamSettings.config
+source fill_origam_settings_config.sh
+fill_origam_settings_config OrigamSettings.config "${DatabaseType}"
+
+# Startup builds a StaticFileProvider for ClientApplication unconditionally; in
+# dev the SPA runs in Vite, so create it empty.
+mkdir -p /home/origam/ClientApplication
+
+export ASPNETCORE_URLS="http://+:8081"
+exec dotnet Origam.Architect.Server.dll

--- a/docker/dev/entrypoint.dev.sh
+++ b/docker/dev/entrypoint.dev.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Development entrypoint: run the published DLL from server_bin so ASP.NET's
+# content root is where configureServer.sh writes the config (same as prod).
+# No nginx/TLS — Vite proxies API/auth to :8080.
+
+set -e
+
+# bootstrap.sh is a no-op unless ORIGAM_PROJECT_BOOTSTRAP=true (consumer flow).
+. /home/origam/server_bin/bootstrap.sh
+
+# Default model location; the compose file bind-mounts the model here.
+if [ -z "${OrigamSettings__ModelSourceControlLocation}" ]; then
+  export OrigamSettings__ModelSourceControlLocation="/home/origam/projectData/model"
+fi
+
+# Docker creates named-volume mount points as root; chown so origam can write
+# Data Protection keys.
+sudo chown -R origam:origam /home/origam/.aspnet/DataProtection-Keys 2>/dev/null || true
+
+# Generate appsettings.json + OrigamSettings.config from templates + env vars.
+cd /home/origam/server_bin
+./configureServer.sh
+
+# Startup builds a StaticFileProvider for PathToClientApp unconditionally; in
+# dev the SPA runs in Vite, so create the dir empty.
+mkdir -p /home/origam/server_bin/clients/origam
+
+export ASPNETCORE_URLS="http://+:8080"
+exec dotnet Origam.Server.dll

--- a/docker/dev/initdb/01-init.sql
+++ b/docker/dev/initdb/01-init.sql
@@ -1,0 +1,14 @@
+-- The backend connects to [origam-dev] as sa, so this just needs to exist.
+-- Origam's deployment service creates the rest of the schema (including the
+-- OrigamModelVersion/AsapModelVersion tables) on first boot.
+
+IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'origam-dev')
+BEGIN
+    CREATE DATABASE [origam-dev];
+    PRINT 'Created origam-dev database';
+END
+ELSE
+BEGIN
+    PRINT 'origam-dev database already exists';
+END
+GO

--- a/docker/dev/initdb/run-init.sh
+++ b/docker/dev/initdb/run-init.sh
@@ -10,7 +10,7 @@ SQL_PID=$!
 
 # Wait for SQL Server to be ready
 echo "Waiting for SQL Server to start..."
-while ! sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -C -Q 'SELECT 1' 2>/dev/null; do
+while ! sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -Q 'SELECT 1' 2>/dev/null; do
     sleep 2
 done
 echo "SQL Server is ready."
@@ -20,7 +20,7 @@ if [ -d /docker-entrypoint-initdb.d ]; then
     for f in /docker-entrypoint-initdb.d/*.sql; do
         if [ -f "$f" ]; then
             echo "Running init script: $f"
-            sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -C -i "$f" || true
+            sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -i "$f" || true
         fi
     done
 fi

--- a/docker/dev/initdb/run-init.sh
+++ b/docker/dev/initdb/run-init.sh
@@ -3,6 +3,16 @@ set -e
 
 export PATH="$PATH:/opt/mssql-tools18/bin"
 
+# The compose files default MSSQL_SA_PASSWORD to empty (so ps/logs/build run
+# without the .env). Fail fast here so a bare `up` without the .env gets a clear
+# message instead of MSSQL's cryptic "Password validation failed ... too short".
+if [ -z "${MSSQL_SA_PASSWORD:-}" ]; then
+  echo "ERROR: MSSQL_SA_PASSWORD is not set. Provide it via the dev .env file:" >&2
+  echo "  - main stack:   cp docker/dev/.env.example docker/dev/.env, then: docker compose --env-file docker/dev/.env up" >&2
+  echo "  - devcontainer: cp .devcontainer/.env.example .devcontainer/.env (auto-loaded by Compose)" >&2
+  exit 1
+fi
+
 # Run the original entrypoint to set permissions, then start sqlservr in background
 # Use full path since sqlservr is not in PATH
 /opt/mssql/bin/permissions_check.sh /opt/mssql/bin/sqlservr &

--- a/docker/dev/initdb/run-init.sh
+++ b/docker/dev/initdb/run-init.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+export PATH="$PATH:/opt/mssql-tools18/bin"
+
+# Run the original entrypoint to set permissions, then start sqlservr in background
+# Use full path since sqlservr is not in PATH
+/opt/mssql/bin/permissions_check.sh /opt/mssql/bin/sqlservr &
+SQL_PID=$!
+
+# Wait for SQL Server to be ready
+echo "Waiting for SQL Server to start..."
+while ! sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -C -Q 'SELECT 1' 2>/dev/null; do
+    sleep 2
+done
+echo "SQL Server is ready."
+
+# Run init scripts
+if [ -d /docker-entrypoint-initdb.d ]; then
+    for f in /docker-entrypoint-initdb.d/*.sql; do
+        if [ -f "$f" ]; then
+            echo "Running init script: $f"
+            sqlcmd -S localhost -U sa -P "$SA_PASSWORD" -C -i "$f" || true
+        fi
+    done
+fi
+
+# Wait for the background SQL Server process (keeps container alive)
+wait $SQL_PID

--- a/docker/dev/log4net.config
+++ b/docker/dev/log4net.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+  <appender name="Console" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+    </layout>
+  </appender>
+  <appender name="FileAppender" type="log4net.Appender.RollingFileAppender">
+    <file value="logs/OrigamServer.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="5" />
+    <maximumFileSize value="10MB" />
+    <staticLogFileName value="true" />
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%date [%thread] %-5level %logger - %message%newline" />
+    </layout>
+  </appender>
+  <root>
+    <level value="INFO" />
+    <appender-ref ref="FileAppender" />
+    <appender-ref ref="Console" />
+  </root>
+</log4net>

--- a/frontend-html/src/oauth.ts
+++ b/frontend-html/src/oauth.ts
@@ -23,10 +23,10 @@ const isDev = import.meta.env.DEV;
 
 const frontendOrigin = window.location.origin;
 
-// In dev, the identity server still runs on 44357, so fix authority accordingly
-const authority = isDev
-  ? "https://localhost:44357"
-  : frontendOrigin; // in prod, SPA is served by the server
+// oidc-client-ts fetches the discovery doc from here. Docker proxies the OIDC
+// endpoints through Vite, so the authority is the SPA origin there.
+const authority = import.meta.env.VITE_OIDC_AUTHORITY
+  ?? (isDev ? "https://localhost:44357" : frontendOrigin);
 
 const redirectBase = frontendOrigin; // where the SPA is actually running (5173 in dev, server in prod)
 

--- a/frontend-html/src/react-app-env.d.ts
+++ b/frontend-html/src/react-app-env.d.ts
@@ -26,6 +26,7 @@ interface ImportMetaEnv {
   readonly VITE_REACT_APP_ORIGAM_CUSTOM_CLIENT_BUILD?: string;
   readonly VITE_REACT_APP_ORIGAM_UI_PLUGINS?: string;
   readonly VITE_REACT_APP_ORIGAM_SERVER_PLUGINS?: string;
+  readonly VITE_OIDC_AUTHORITY?: string;
 }
 
 interface ImportMeta {

--- a/frontend-html/vite.config.ts
+++ b/frontend-html/vite.config.ts
@@ -28,6 +28,7 @@ const useBasicSsl = !localHttpsCertificate;
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const nodeEnv = mode === "production" ? "production" : "development";
+  const proxyTarget = process.env.VITE_PROXY_TARGET || 'https://localhost:44357';
 
   return {
 	plugins: [
@@ -134,57 +135,57 @@ export default defineConfig(({ mode }) => {
 	},
 	server: {
     https: localHttpsCertificate ?? {},
-    host: "localhost",
+    host: process.env.VITE_HOST || "localhost",
 		proxy: {
       // OpenIddict endpoints
       '/.well-known': {
-        target: 'https://localhost:44357',
+        target: proxyTarget,
         secure: false,
         changeOrigin: true,
+        xfwd: true,
       },
       '/connect': {
-        target: 'https://localhost:44357',
+        target: proxyTarget,
         secure: false,
         changeOrigin: true,
+        xfwd: true,
       },
       // ASP.NET Identity endpoints
       '/Account': {
-        target: 'https://localhost:44357',
+        target: proxyTarget,
         secure: false,
         changeOrigin: true,
+        xfwd: true,
       },
       '/account': {
-        target: 'https://localhost:44357',
+        target: proxyTarget,
         secure: false,
         changeOrigin: true,
+        xfwd: true,
       },
       // Origam.Server endpoints
 			'/internalApi':{
-				target: "https://localhost:44357",
+				target: proxyTarget,
 				secure: false
 			},
 			'/customAssets':{
-				target: "https://localhost:44357",
+				target: proxyTarget,
 				secure: false
 			},
 			'/chatrooms':{
-				target: "https://localhost:44357",
+				target: proxyTarget,
 				secure: false
 			},
 			'/api':{
-				target: "https://localhost:44357",
+				target: proxyTarget,
 				secure: false
 			},
 			'/assets':{
-				target: "https://localhost:44357",
+				target: proxyTarget,
 				secure: false
 			},
 			'/home':{
-				target: "https://localhost:44357",
-				secure: false
-			},
-			'/locale':{
-				target: "https://localhost:44357",
+				target: proxyTarget,
 				secure: false
 			}
 		}


### PR DESCRIPTION
Run and debug Origam on any platform with Docker as the only requirement.

Adds:

- Docker Compose dev stack: `docker compose up -d` - spins up DB, Origam server, and frontend; optionally also with Architect. Supports also Postgres with an override. See `docker/dev/README.md`.
- A [devcontainer](https://containers.dev) for debugging inside Docker for VS Code, Cursor, Rider, etc. - clone the repo, open VS Code, choose `Reopen in Container`, set a breakpoint, hit F5 to debug. Automatically starts up frontends. See `.devcontainer/README.md`.

First boot doesn't create a user - create the admin user once via https://localhost:5173/Account/RegisterInitialUser, then log in.

Two backend changes added:

- `ORIGAM_SERVER` is now defined for all "Architect Server" configs (Linux Architect build was failing)
- A missing-table `SqlException` is wrapped as `DatabaseTableNotFoundException` for clean fresh-DB bootstrap

Frontend adds env var overrides for proxy/host/OIDC authority for Docker/host-dev parity.