### PR TITLE
DEV: Omit reliably recreated default XML attribute values

### DIFF
--- a/backend/Origam.DA.Service-net2Tests/InstanceWriterTests.cs
+++ b/backend/Origam.DA.Service-net2Tests/InstanceWriterTests.cs
@@ -21,9 +21,14 @@ along with ORIGAM. If not, see <http://www.gnu.org/licenses/>.
 
 #endregion
 
+using System;
+using Moq;
 using NUnit.Framework;
+using Origam.DA.ObjectPersistence;
 using Origam.DA.Service;
+using Origam.DA.Service.NamespaceMapping;
 using Origam.Schema.EntityModel;
+using Origam.Schema.GuiModel;
 using Origam.Workbench.Services;
 
 namespace Origam.DA.ServiceTests;
@@ -31,6 +36,12 @@ namespace Origam.DA.ServiceTests;
 [TestFixture]
 public class InstanceWriterTests
 {
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        PropertyToNamespaceMapping.Init();
+    }
+
     [Test]
     public void ShouldWriteFile()
     {
@@ -42,5 +53,175 @@ public class InstanceWriterTests
         sut.Write(itemToWrite);
 
         Assert.That(!document.IsEmpty);
+    }
+
+    [Test]
+    public void ShouldOmitFalseXmlAttribute()
+    {
+        var itemToWrite = new TableMappingItem();
+        itemToWrite.GenerateDeploymentScript = false;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Not.Contain("generateDeploymentScript="));
+    }
+
+    [Test]
+    public void ShouldWriteTrueXmlAttribute()
+    {
+        var itemToWrite = new TableMappingItem();
+        itemToWrite.GenerateDeploymentScript = true;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Contain("generateDeploymentScript=\"true\""));
+    }
+
+    [Test]
+    public void ShouldOmitZeroIntegerXmlAttribute()
+    {
+        var itemToWrite = new DataEntityIndexField();
+        itemToWrite.OrdinalPosition = 0;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Not.Contain("ordinalPosition="));
+    }
+
+    [Test]
+    public void ShouldWriteNonZeroIntegerXmlAttribute()
+    {
+        var itemToWrite = new DataEntityIndexField();
+        itemToWrite.OrdinalPosition = 5;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Contain("ordinalPosition=\"5\""));
+    }
+
+    [Test]
+    public void ShouldOmitEmptyGuidXmlAttribute()
+    {
+        var itemToWrite = new ControlSetItem();
+        itemToWrite.MultiColumnAdapterFieldCondition = Guid.Empty;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Not.Contain("multiColumnAdapterFieldCondition="));
+    }
+
+    [Test]
+    public void ShouldWriteNonEmptyGuidXmlAttribute()
+    {
+        var id = Guid.NewGuid();
+        var itemToWrite = new ControlSetItem();
+        itemToWrite.MultiColumnAdapterFieldCondition = id;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Contain($"multiColumnAdapterFieldCondition=\"{id}\""));
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    public void ShouldOmitEmptyStringXmlAttribute(string value)
+    {
+        var itemToWrite = new TableMappingItem();
+        itemToWrite.MappedObjectName = value;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Not.Contain("mappedObjectName="));
+    }
+
+    [Test]
+    public void ShouldWriteNonEmptyStringXmlAttribute()
+    {
+        var itemToWrite = new TableMappingItem();
+        itemToWrite.MappedObjectName = "TestTable";
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Contain("mappedObjectName=\"TestTable\""));
+    }
+
+    [Test]
+    public void ShouldWriteEnumXmlAttribute()
+    {
+        var itemToWrite = new TableMappingItem();
+        itemToWrite.DatabaseObjectType = DatabaseMappingObjectType.Table;
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Contain("databaseObjectType=\"Table\""));
+    }
+
+    private static readonly object[] DefaultPropertyValueItemValueAttributeCases =
+    {
+        new object[] { ControlPropertyValueType.Integer, 0 },
+        new object[] { ControlPropertyValueType.Boolean, false },
+        new object[] { ControlPropertyValueType.String, "" },
+        new object[] { ControlPropertyValueType.UniqueIdentifier, Guid.Empty },
+    };
+
+    [TestCaseSource(nameof(DefaultPropertyValueItemValueAttributeCases))]
+    public void ShouldOmitDefaultPropertyValueItemValueAttribute(
+        ControlPropertyValueType propertyType,
+        object value
+    )
+    {
+        PropertyValueItem itemToWrite = CreatePropertyValueItem(propertyType, value);
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Not.Contain("value="));
+    }
+
+    private static readonly object[] NonDefaultPropertyValueItemValueAttributeCases =
+    {
+        new object[] { ControlPropertyValueType.Integer, 1 },
+        new object[] { ControlPropertyValueType.Boolean, true },
+        new object[] { ControlPropertyValueType.String, "0" },
+        new object[] { ControlPropertyValueType.UniqueIdentifier, Guid.NewGuid() },
+    };
+
+    [TestCaseSource(nameof(NonDefaultPropertyValueItemValueAttributeCases))]
+    public void ShouldWriteNonDefaultPropertyValueItemValueAttribute(
+        ControlPropertyValueType propertyType,
+        object value
+    )
+    {
+        PropertyValueItem itemToWrite = CreatePropertyValueItem(propertyType, value);
+
+        string xml = WriteToXml(itemToWrite);
+
+        Assert.That(xml, Does.Contain("value="));
+    }
+
+    private PropertyValueItem CreatePropertyValueItem(
+        ControlPropertyValueType propertyType,
+        object value
+    )
+    {
+        var propertyItem = new ControlPropertyItem { PropertyType = propertyType };
+        var persistenceProvider = new Mock<IPersistenceProvider>();
+        persistenceProvider
+            .Setup(provider =>
+                provider.RetrieveInstance(typeof(ControlPropertyItem), It.IsAny<Key>(), true, false)
+            )
+            .Returns(propertyItem);
+        var valueItem = new PropertyValueItem { PersistenceProvider = persistenceProvider.Object };
+        valueItem.ControlPropertyItem = propertyItem;
+        valueItem.SetValue(value);
+        return valueItem;
+    }
+
+    private string WriteToXml(IFilePersistent itemToWrite)
+    {
+        itemToWrite.PersistenceProvider = new NullPersistenceProvider();
+        OrigamXmlDocument document = new OrigamXmlDocument();
+        InstanceWriter sut = new InstanceWriter(new NullExternalFileManager(), document);
+        sut.Write(itemToWrite);
+        return document.OuterXml;
     }
 }

--- a/backend/Origam.DA.Service/InstanceWriter.cs
+++ b/backend/Origam.DA.Service/InstanceWriter.cs
@@ -249,12 +249,7 @@ namespace Origam.DA.Service
                 XmlAttributeAttribute attribute = (XmlAttributeAttribute)memberInfo.Attribute;
                 object value = GetValueToWrite(instance, memberInfo);
 
-                if (ShouldBeSkipped(value))
-                {
-                    continue;
-                }
-
-                if (Guid.Empty.Equals(value))
+                if (ShouldBeSkipped(instance, memberInfo, value))
                 {
                     continue;
                 }
@@ -269,21 +264,54 @@ namespace Origam.DA.Service
             }
         }
 
-        private bool ShouldBeSkipped(object value)
+        private bool ShouldBeSkipped(
+            IFilePersistent instance,
+            MemberAttributeInfo memberInfo,
+            object value
+        )
         {
-            if (ReferenceEquals(value, null))
+            if (IsSemanticPropertyValueDefault(instance, memberInfo))
             {
                 return true;
             }
 
             if (value is Enum)
             {
+                // Some enum defaults are not the CLR zero value. For example,
+                // ScheduleIntervalType.Daily is 4, so missing XML would not recreate it.
                 return false;
             }
 
-            if (value is bool)
+            return IsReliablyRecreatedDefault(value);
+        }
+
+        private bool IsSemanticPropertyValueDefault(
+            IFilePersistent instance,
+            MemberAttributeInfo memberInfo
+        )
+        {
+            if (
+                instance.GetType().FullName != "Origam.Schema.GuiModel.PropertyValueItem"
+                || memberInfo.MemberInfo.Name != "Value"
+            )
             {
                 return false;
+            }
+
+            object typedValue = GetPropertyValue(instance, "TypedValue");
+            return IsReliablyRecreatedDefault(typedValue);
+        }
+
+        private bool IsReliablyRecreatedDefault(object value)
+        {
+            if (ReferenceEquals(value, null))
+            {
+                return true;
+            }
+
+            if (value is bool boolValue)
+            {
+                return boolValue == false;
             }
 
             if (value is string strValue)
@@ -291,7 +319,29 @@ namespace Origam.DA.Service
                 return string.IsNullOrEmpty(strValue);
             }
 
-            return value.IsDefault();
+            if (value is int intValue)
+            {
+                return intValue == 0;
+            }
+
+            if (value is Guid guidValue)
+            {
+                return guidValue == Guid.Empty;
+            }
+
+            return false;
+        }
+
+        private static object GetPropertyValue(object instance, string propertyName)
+        {
+            try
+            {
+                return instance.GetType().GetProperty(propertyName)?.GetValue(instance);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private void WriteXmlExternalFiles(

--- a/backend/Origam.DA.Service/InstanceWriter.cs
+++ b/backend/Origam.DA.Service/InstanceWriter.cs
@@ -33,6 +33,9 @@ namespace Origam.DA.Service
 {
     public class InstanceWriter
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(
+            MethodBase.GetCurrentMethod().DeclaringType
+        );
         private readonly IExternalFileManager externalFileManger;
         private readonly OrigamXmlDocument xmlDocument;
 
@@ -338,8 +341,9 @@ namespace Origam.DA.Service
             {
                 return instance.GetType().GetProperty(propertyName)?.GetValue(instance);
             }
-            catch
+            catch (Exception exception)
             {
+                log.Warn($"Could not read property value '{propertyName}'.", exception);
                 return null;
             }
         }


### PR DESCRIPTION
Skip writing default XML attributes for values that are safely restored when missing: null, empty string, false, zero integer, and empty Guid. Handle PropertyValueItem.Value by checking its typed value so default control property values are also omitted.

Add InstanceWriter coverage for skipped and preserved attributes, including enums, null strings, and typed PropertyValueItem values.