### PR TITLE
FIX: Model tree not refreshed correctly after saving new or inherited items /architect-html

### DIFF
--- a/architect-html/src/components/editors/designerEditor/common/DesignerEditorState.tsx
+++ b/architect-html/src/components/editors/designerEditor/common/DesignerEditorState.tsx
@@ -80,8 +80,8 @@ export abstract class DesignerEditorState implements IDesignerEditorState {
   protected abstract update(): Generator<Promise<any>, void, any>;
 
   *save(): Generator<Promise<any>, void, any> {
-    if (this.editorNode.parent?.parent) {
-      yield* this.editorNode.parent.parent.loadChildren();
+    if (this.editorNode.parent) {
+      yield* this.editorNode.parent.reloadTree();
     }
     this.isDirty = false;
   }

--- a/architect-html/src/components/editors/documentationEditor/DocumentationEditorState.ts
+++ b/architect-html/src/components/editors/documentationEditor/DocumentationEditorState.ts
@@ -46,8 +46,8 @@ export class DocumentationEditorState extends GridEditorState {
     try {
       this.isSaving = true;
       yield this.architectApi.persistDocumentationChanges(this.editorNode.origamId);
-      if (this.editorNode.parent?.parent) {
-        yield* this.editorNode.parent.parent.loadChildren();
+      if (this.editorNode.parent) {
+        yield* this.editorNode.parent.reloadTree();
       }
       this._isDirty = false;
     } finally {

--- a/architect-html/src/components/editors/gridEditor/GridEditorState.ts
+++ b/architect-html/src/components/editors/gridEditor/GridEditorState.ts
@@ -79,8 +79,8 @@ export class GridEditorState implements ITabState, IPropertyManager {
     try {
       this.isSaving = true;
       yield this.architectApi.persistChanges(this.editorNode.origamId);
-      if (this.editorNode.parent?.parent) {
-        yield* this.editorNode.parent.parent.loadChildren();
+      if (this.editorNode.parent) {
+        yield* this.editorNode.parent.reloadTree();
       }
       this._isDirty = false;
     } finally {

--- a/architect-html/src/components/modelTree/TreeNode.ts
+++ b/architect-html/src/components/modelTree/TreeNode.ts
@@ -161,8 +161,8 @@ export class TreeNode implements IEditorNode {
   }
 
   createNode(typeName: string) {
-    return function* (this: TreeNode): Generator<Promise<IApiTabData>, void, IApiTabData> {
-      const apiTabData = yield this.architectApi.createNode(this, typeName);
+    return function* (this: TreeNode) {
+      const apiTabData: IApiTabData = yield this.architectApi.createNode(this, typeName);
       const editorData = new EditorData(apiTabData, this);
       this.rootStore.editorTabViewState.openEditor(editorData);
       yield* this.loadChildren.bind(this)();

--- a/architect-html/src/components/modelTree/TreeNode.ts
+++ b/architect-html/src/components/modelTree/TreeNode.ts
@@ -134,6 +134,10 @@ export class TreeNode implements IEditorNode {
     yield;
   }
 
+  *reloadTree(): Generator<Promise<any>, void, any> {
+    yield* this.rootStore.modelTreeState.loadPackageNodes();
+  }
+
   *delete() {
     yield this.architectApi.deleteSchemaItem(this.origamId);
     if (this.parent) {
@@ -161,6 +165,8 @@ export class TreeNode implements IEditorNode {
       const apiTabData = yield this.architectApi.createNode(this, typeName);
       const editorData = new EditorData(apiTabData, this);
       this.rootStore.editorTabViewState.openEditor(editorData);
+      yield* this.loadChildren.bind(this)();
+      this.rootStore.uiState.setExpanded(this.id, true);
     }.bind(this);
   }
 }

--- a/test/architect-html-e2e/integration/entity/relationship-creation.spec.ts
+++ b/test/architect-html-e2e/integration/entity/relationship-creation.spec.ts
@@ -49,7 +49,7 @@ test.describe('Entity Relationship creation (real backend)', () => {
     await expect(page.getByTestId('save-button-disabled')).toBeVisible();
 
     await page.getByTestId('tree-toggle-DimensionEntity').click();
-    await page.getByTestId('tree-toggle-Relationships').click();
+    await page.getByTestId('tree-toggle-Relationships').first().click();
     await page.getByTestId('tree-toggle-Dimension4').click();
     await page.getByTestId('tree-toggle-_Ancestors').first().click();
     await page.getByTestId('tree-node-SourceDimensionEntityRelation').dblclick();


### PR DESCRIPTION
* Fixed the model tree not showing new or updated items correctly after saving
* New nodes now appear immediately in the tree right after creation, with their parent expanded automatically
* Adjusted an E2E test to match the updated tree behavior