### PR TITLE
DEV: Increase dependency update cooldown from 1 to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 1
+      default-days: 7
       include:
         - "*"
     commit-message:
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 1
+      default-days: 7
       include:
         - "*"
     commit-message:
@@ -32,7 +32,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 1
+      default-days: 7
       include:
         - "*"
     commit-message:
@@ -46,7 +46,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 1
+      default-days: 7
       include:
         - "*"
     commit-message:

--- a/architect-html/.yarnrc.yml
+++ b/architect-html/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
 enableScripts: false
-npmMinimalAgeGate: '24h'
+npmMinimalAgeGate: '7d'

--- a/chat-html/.yarnrc.yml
+++ b/chat-html/.yarnrc.yml
@@ -3,4 +3,4 @@ logFilters:
     level: discard
 enableScripts: false
 nodeLinker: node-modules
-npmMinimalAgeGate: "24h"
+npmMinimalAgeGate: "7d"

--- a/frontend-html/.yarnrc.yml
+++ b/frontend-html/.yarnrc.yml
@@ -6,4 +6,4 @@ logFilters:
 
 enableScripts: false
 nodeLinker: node-modules
-npmMinimalAgeGate: "24h"
+npmMinimalAgeGate: "7d"

--- a/test/architect-html-e2e/.yarnrc.yml
+++ b/test/architect-html-e2e/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
 enableScripts: false
-npmMinimalAgeGate: '24h'
+npmMinimalAgeGate: '7d'


### PR DESCRIPTION
## Summary

Raises the protective delay before newly published dependency versions can reach `master` from 1 day to 7 days. Compromised npm/NuGet releases are usually pulled within days of publication; a one-day window is short enough that a bad version can be merged before it is flagged.

## Changes

- `.github/dependabot.yml` - `cooldown.default-days` `1` → `7` for all four ecosystems (`/backend`, `/frontend-html`, `/architect-html`, `/chat-html`)
- `npmMinimalAgeGate` `24h` → `7d` in `architect-html`, `frontend-html`, `chat-html` and `test/architect-html-e2e` `.yarnrc.yml`, so local installs match CI

## Impact

Dependency PRs arrive about a week later. Existing lockfiles are untouched. Security advisories are unaffected - Dependabot security updates ignore `cooldown`.

`test/tests_e2e` is not covered: it is still on Yarn 1, which has no `npmMinimalAgeGate`, and has no Dependabot entry. Proposed separately.